### PR TITLE
use the COUCHHOST constant

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,7 @@ unless defined?(FIXTURE_PATH)
 
   COUCHHOST = "http://127.0.0.1:5984"
   TESTDB    = 'couchrest-model-test'
-  TEST_SERVER    = CouchRest.new
+  TEST_SERVER    = CouchRest.new COUCHHOST
   TEST_SERVER.default_database = TESTDB
   DB = TEST_SERVER.database(TESTDB)
 end


### PR DESCRIPTION
It seems the COUCHHOST constant was unused - I used it for the TEST_SERVER initialization.
