### PR TITLE
Bug fix: Default properties are "deep cloned"

### DIFF
--- a/lib/couchrest/model/property.rb
+++ b/lib/couchrest/model/property.rb
@@ -58,8 +58,8 @@ module CouchRest::Model
       if default.class == Proc
         default.call
       else
-        # Marshal.load(Marshal.dump(default)) # Removed as there are no failing tests and caused mutex errors
-        default
+        # TODO identify cause of mutex errors
+        Marshal.load(Marshal.dump(default))
       end
     end
 

--- a/spec/couchrest/base_spec.rb
+++ b/spec/couchrest/base_spec.rb
@@ -184,6 +184,14 @@ describe "Model Base" do
       obj = WithDefaultValues.new(:preset => 'test')
       obj.preset = 'test'
     end
+
+    it "should keep default values for new instances" do
+      obj = WithDefaultValues.new
+      obj.preset[:alpha] = 123
+      obj.preset.should == {:right => 10, :top_align => false, :alpha => 123}
+      another = WithDefaultValues.new
+      another.preset.should == {:right => 10, :top_align => false}
+    end
     
     it "should work with a default empty array" do
       obj = WithDefaultValues.new(:tags => ['spec'])


### PR DESCRIPTION
Deep clone the default value for properties for each instance to prevent unexpected changes between Document instances.
