### PR TITLE
Feature: Validation :message option for CastedModel properties

### DIFF
--- a/lib/couchrest/model/properties.rb
+++ b/lib/couchrest/model/properties.rb
@@ -159,11 +159,13 @@ module CouchRest
               type.class_eval { yield type }
               type = [type] # inject as an array
             end
+            validation_options = {}
+            validation_options[:message] = options.delete(:message) if options[:message]
             property = Property.new(name, type, options)
             create_property_getter(property)
             create_property_setter(property) unless property.read_only == true
             if property.type_class.respond_to?(:validates_casted_model)
-              validates_casted_model property.name
+              validates_casted_model property.name, validation_options
             end
             properties << property
             property

--- a/spec/couchrest/casted_model_spec.rb
+++ b/spec/couchrest/casted_model_spec.rb
@@ -284,6 +284,20 @@ describe CouchRest::Model::CastedModel do
         @toy2.errors.should be_empty
         @toy3.errors.should_not be_empty
       end
+
+      it "should use custom error message when specified" do
+        @cat.should_not be_valid
+        @cat.errors[:toys].should have(1).element
+        @cat.errors[:toys].first.should == "gotta have 'em"
+      end
+
+      it "should default error message when none is specified" do
+        @toy2.name = "Twine"
+        @toy3.name = "Bell"
+        @cat.should_not be_valid
+        @cat.errors[:favorite_toy].should have(1).element
+        @cat.errors[:favorite_toy].first.should match /invalid/
+      end
     end
 
     describe "on a casted model property" do

--- a/spec/fixtures/more/cat.rb
+++ b/spec/fixtures/more/cat.rb
@@ -12,7 +12,7 @@ class Cat < CouchRest::Model::Base
   use_database DB
 
   property :name, :accessible => true
-  property :toys, [CatToy], :default => [], :accessible => true
+  property :toys, [CatToy], :default => [], :accessible => true, :message => "gotta have 'em"
   property :favorite_toy, CatToy, :accessible => true
   property :number
 end


### PR DESCRIPTION
CastedModel properties are automatically validated, now you can specify a custom message.

```
    property :toys, [CatToy], :default => [], :message => "gotta have 'em"
```

or

```
    property :toys, [CatToy], :default => [], :message => :necessary_toys
```
