### PR TITLE
Bug fix: Validation callbacks are now always run at the proper time

### DIFF
--- a/lib/couchrest/model/callbacks.rb
+++ b/lib/couchrest/model/callbacks.rb
@@ -12,8 +12,7 @@ module CouchRest #:nodoc:
           :create,
           :destroy,
           :save,
-          :update,
-          :validate
+          :update
 
       end
 

--- a/lib/couchrest/model/validations.rb
+++ b/lib/couchrest/model/validations.rb
@@ -15,6 +15,7 @@ module CouchRest
       extend ActiveSupport::Concern
       included do
         include ActiveModel::Validations
+        include ActiveModel::Validations::Callbacks
       end
       
 

--- a/spec/couchrest/casted_model_spec.rb
+++ b/spec/couchrest/casted_model_spec.rb
@@ -29,14 +29,16 @@ end
 class WithCastedCallBackModel < Hash
   include CouchRest::Model::CastedModel
   property :name
-  property :run_before_validate
-  property :run_after_validate
+  property :run_before_validation
+  property :run_after_validation
 
-  before_validate do |object|
-    object.run_before_validate = true
+  validates_presence_of :run_before_validation
+
+  before_validation do |object|
+    object.run_before_validation = true
   end
-  after_validate do |object|
-    object.run_after_validate = true
+  after_validation do |object|
+    object.run_after_validation = true
   end
 end
 
@@ -423,15 +425,15 @@ describe CouchRest::Model::CastedModel do
     end
 
     describe "validate" do
-      it "should run before_validate before validating" do
-        @model.run_before_validate.should be_nil
+      it "should run before_validation before validating" do
+        @model.run_before_validation.should be_nil
         @model.should be_valid
-        @model.run_before_validate.should be_true
+        @model.run_before_validation.should be_true
       end
-      it "should run after_validate after validating" do
-        @model.run_after_validate.should be_nil
+      it "should run after_validation after validating" do
+        @model.run_after_validation.should be_nil
         @model.should be_valid
-        @model.run_after_validate.should be_true
+        @model.run_after_validation.should be_true
       end
     end
   end

--- a/spec/couchrest/persistence_spec.rb
+++ b/spec/couchrest/persistence_spec.rb
@@ -329,14 +329,14 @@ describe "Model Persistence" do
     
     describe "validation" do
       it "should run before_validation before validating" do
-        @doc.run_before_validate.should be_nil
+        @doc.run_before_validation.should be_nil
         @doc.should be_valid
-        @doc.run_before_validate.should be_true
+        @doc.run_before_validation.should be_true
       end
       it "should run after_validation after validating" do
-        @doc.run_after_validate.should be_nil
+        @doc.run_after_validation.should be_nil
         @doc.should be_valid
-        @doc.run_after_validate.should be_true
+        @doc.run_after_validation.should be_true
       end
     end
 

--- a/spec/fixtures/base.rb
+++ b/spec/fixtures/base.rb
@@ -20,20 +20,22 @@ end
 class WithCallBacks < CouchRest::Model::Base
   use_database TEST_SERVER.default_database
   property :name
-  property :run_before_validate
-  property :run_after_validate
+  property :run_before_validation
+  property :run_after_validation
   property :run_before_save
   property :run_after_save
   property :run_before_create
   property :run_after_create
   property :run_before_update
   property :run_after_update
+
+  validates_presence_of :run_before_validation
   
-  before_validate do |object|
-    object.run_before_validate = true
+  before_validation do |object|
+    object.run_before_validation = true
   end
-  after_validate do |object| 
-    object.run_after_validate = true
+  after_validation do |object| 
+    object.run_after_validation = true
   end
   before_save do |object| 
     object.run_before_save = true


### PR DESCRIPTION
Use :validation callbacks, not the :validate callbacks reserved by ActiveModel, ensuring callbacks are actually run when they're supposed to be.

[See related ticket](https://rails.lighthouseapp.com/projects/8994/tickets/4653-before_validation-callbacks-being-run-after-validation-actvemodel-300beta3)
