### PR TITLE
Numbers can be casted from strings with whitespace

### DIFF
--- a/lib/couchrest/model/typecast.rb
+++ b/lib/couchrest/model/typecast.rb
@@ -79,7 +79,7 @@ module CouchRest
         # Match numeric string
         def typecast_to_numeric(value, method)
           if value.respond_to?(:to_str)
-            if value.gsub(/,/, '.').gsub(/\.(?!\d*\Z)/, '').to_str =~ /\A(-?(?:0|[1-9]\d*)(?:\.\d+)?|(?:\.\d+))\z/
+            if value.strip.gsub(/,/, '.').gsub(/\.(?!\d*\Z)/, '').to_str =~ /\A(-?(?:0|[1-9]\d*)(?:\.\d+)?|(?:\.\d+))\z/
               $1.send(method)
             else
               value

--- a/spec/couchrest/property_spec.rb
+++ b/spec/couchrest/property_spec.rb
@@ -340,6 +340,11 @@ describe "Model properties" do
         @course.estimate.should eql(1232434123.323)
       end
 
+      it "should handle numbers with whitespace" do
+        @course.estimate = " 24.35 "
+        @course.estimate.should eql(24.35)
+      end
+
       [ Object.new, true, '00.0', '0.', '-.0', 'string' ].each do |value|
         it "does not typecast non-numeric value #{value.inspect}" do
           @course.estimate = value
@@ -426,6 +431,11 @@ describe "Model properties" do
         @course['hours'].should eql(-24)
       end
 
+      it "should handle numbers with whitespace" do
+        @course.hours = " 24 "
+        @course['hours'].should eql(24)
+      end
+
       [ Object.new, true, '00.0', '0.', '-.0', 'string' ].each do |value|
         it "does not typecast non-numeric value #{value.inspect}" do
           @course.hours = value
@@ -509,6 +519,11 @@ describe "Model properties" do
       it 'returns decimal representation of a negative float' do
         @course.profit = -24.35
         @course['profit'].should eql(BigDecimal('-24.35'))
+      end
+
+      it "should handle numbers with whitespace" do
+        @course.profit = " 24.35 "
+        @course['profit'].should eql(BigDecimal('24.35'))
       end
 
       [ Object.new, true, '00.0', '0.', '-.0', 'string' ].each do |value|


### PR DESCRIPTION
The attached patch allows strings with leading or trailing whitespace to be casted as Integer, Float, and BigDecimal. For example, " 24 " will be cast as the Integer 24.
