### PR TITLE
Bug fix: belongs_to in CastedModel doesn't work properly

### DIFF
--- a/lib/couchrest/model/casted_model.rb
+++ b/lib/couchrest/model/casted_model.rb
@@ -53,6 +53,13 @@ module CouchRest::Model
     end
     alias :to_key :id
     alias :to_param :id
+
+    # Fixes belongs_to assocations. 
+    # See it "should allow to reference association by id in casted model" in 
+    # assocations_spec.rb
+    def model_proxy 
+      nil
+    end
     
     # Sets the attributes from a hash
     def update_attributes_without_saving(hash)

--- a/spec/couchrest/assocations_spec.rb
+++ b/spec/couchrest/assocations_spec.rb
@@ -64,6 +64,22 @@ describe "Assocations" do
       @invoice.alternate_client.id.should eql(@client.id)
     end
 
+    it "should allow to reference association by id in casted model" do
+      class Money < Hash
+        include CouchRest::Model::CastedModel
+
+        property :value, Integer
+        belongs_to :client
+      end
+
+      money = Money.new :value => 1000
+
+      money.client_id = @client.id
+
+      money.client.should eql(@client)
+      money.valid?.should be_true
+    end
+
   end
 
   describe "of type collection_of" do


### PR DESCRIPTION
I've found and issue with belong_to properties in CastedModel, I've written test reproducing this issue (see it "should allow to reference association by id in casted model" in spec/couchrest/assocations_spec.rb) and code fixing it.
