### PR TITLE
Implement #get! and #find! class methods

### DIFF
--- a/lib/couchrest/model/class_proxy.rb
+++ b/lib/couchrest/model/class_proxy.rb
@@ -87,7 +87,14 @@ module CouchRest
           doc
         end
         alias :find :get
-        
+
+        def get!(id)
+          doc = @klass.get!(id, @database)
+          doc.database = @database if doc && doc.respond_to?(:database)
+          doc
+        end
+        alias :find! :get!
+
         # Views
         
         def has_view?(view)

--- a/lib/couchrest/model/document_queries.rb
+++ b/lib/couchrest/model/document_queries.rb
@@ -86,9 +86,12 @@ module CouchRest
         # id<String, Integer>:: Document ID
         # db<Database>:: optional option to pass a custom database to use
         def get!(id, db = database)
-          raise "Missing or empty document ID" if id.to_s.empty?
+          raise CouchRest::Model::DocumentNotFound if id.blank?
+
           doc = db.get id
           build_from_database(doc)
+        rescue RestClient::ResourceNotFound
+          raise CouchRest::Model::DocumentNotFound
         end
         alias :find! :get!
         

--- a/lib/couchrest/model/errors.rb
+++ b/lib/couchrest/model/errors.rb
@@ -19,5 +19,7 @@ module CouchRest
         end
       end
     end
+
+    class DocumentNotFound < Errors::CouchRestModelError; end
   end
 end

--- a/spec/couchrest/class_proxy_spec.rb
+++ b/spec/couchrest/class_proxy_spec.rb
@@ -123,6 +123,35 @@ describe "Proxy Class" do
       u.respond_to?(:database).should be_false
     end
   end
+
+  describe "#get!" do 
+    it "raises exception when passed a nil" do 
+      expect { @us.get!(nil)}.to raise_error(CouchRest::Model::DocumentNotFound)
+    end
+    
+    it "raises exception when passed an empty string " do 
+      expect { @us.get!("")}.to raise_error(CouchRest::Model::DocumentNotFound)
+    end
+    
+    it "raises exception when document with provided id does not exist" do 
+      expect { @us.get!("thisisnotreallyadocumentid")}.to raise_error(CouchRest::Model::DocumentNotFound)
+    end
+  end
+
+  describe "#find!" do 
+    it "raises exception when passed a nil" do 
+      expect { @us.find!(nil)}.to raise_error(CouchRest::Model::DocumentNotFound)
+    end
+    
+    it "raises exception when passed an empty string " do 
+      expect { @us.find!("")}.to raise_error(CouchRest::Model::DocumentNotFound)
+    end
+    
+    it "raises exception when document with provided id does not exist" do 
+      expect { @us.find!("thisisnotreallyadocumentid")}.to raise_error(CouchRest::Model::DocumentNotFound)
+    end
+  end
+
   # Sam Lown 2010-04-07
   # Removed as unclear why this should happen as before my changes 
   # this happend by accident, not explicitly.


### PR DESCRIPTION
Surfaced #get! and #find! methods so that users can receive an exception when trying to get/find a non-existent document.
