### PR TITLE
Should be able to set contextual validations

### DIFF
--- a/lib/couchrest/model/base.rb
+++ b/lib/couchrest/model/base.rb
@@ -7,7 +7,6 @@ module CouchRest
       include CouchRest::Model::Configuration
       include CouchRest::Model::Connection
       include CouchRest::Model::Persistence
-      include CouchRest::Model::Callbacks
       include CouchRest::Model::DocumentQueries
       include CouchRest::Model::Views
       include CouchRest::Model::DesignDoc
@@ -21,6 +20,7 @@ module CouchRest
       include CouchRest::Model::Designs
       include CouchRest::Model::CastedBy
       include CouchRest::Model::Dirty
+      include CouchRest::Model::Callbacks
 
       def self.subclasses
         @subclasses ||= []

--- a/lib/couchrest/model/callbacks.rb
+++ b/lib/couchrest/model/callbacks.rb
@@ -16,8 +16,10 @@ module CouchRest #:nodoc:
 
       end
 
-      def valid?(*) #nodoc
-        _run_validation_callbacks { super }
+      def valid?(context = nil)
+        context ||= (new_record? ? :create : :update)
+        output = super(context)
+        errors.empty? && output
       end
 
     end

--- a/lib/couchrest/model/casted_model.rb
+++ b/lib/couchrest/model/casted_model.rb
@@ -5,13 +5,14 @@ module CouchRest::Model
 
     included do
       include CouchRest::Model::Configuration
-      include CouchRest::Model::Callbacks
       include CouchRest::Model::Properties
       include CouchRest::Model::PropertyProtection
       include CouchRest::Model::Associations
       include CouchRest::Model::Validations
       include CouchRest::Model::CastedBy
       include CouchRest::Model::Dirty
+      include CouchRest::Model::Callbacks
+
       class_eval do
         # Override CastedBy's base_doc?
         def base_doc?

--- a/spec/couchrest/persistence_spec.rb
+++ b/spec/couchrest/persistence_spec.rb
@@ -362,6 +362,27 @@ describe "Model Persistence" do
       end
     end
 
+    describe "with contextual validation on ”create”" do
+      it "should validate only within ”create” context" do
+        doc = WithContextualValidationOnCreate.new
+        doc.save.should be_false
+        doc.name = "Alice"
+        doc.save.should be_true
+
+        doc.update_attributes(:name => nil).should be_true
+      end
+    end
+
+    describe "with contextual validation on ”update”" do
+      it "should validate only within ”update” context" do
+        doc = WithContextualValidationOnUpdate.new
+        doc.save.should be_true
+
+        doc.update_attributes(:name => nil).should be_false
+        doc.update_attributes(:name => "Bob").should be_true
+      end
+    end
+
     describe "save" do
       it "should run the after filter after saving" do
         @doc.run_after_save.should be_nil

--- a/spec/fixtures/base.rb
+++ b/spec/fixtures/base.rb
@@ -83,6 +83,17 @@ class WithCallBacks < CouchRest::Model::Base
   end
 end
 
+# Following two fixture classes have __intentionally__ diffent syntax for setting the validation context
+class WithContextualValidationOnCreate < CouchRest::Model::Base
+  property(:name, String)
+  validates(:name, :presence => {:on => :create})
+end
+
+class WithContextualValidationOnUpdate < CouchRest::Model::Base
+  property(:name, String)
+  validates(:name, :presence => true, :on => :update)
+end
+
 class WithTemplateAndUniqueID < CouchRest::Model::Base
   use_database TEST_SERVER.default_database
   unique_id do |model|


### PR DESCRIPTION
Contextual validations are active **only** within
an appropriate context: either ”create" or ”update”.

``` ruby
validates(:name, :presence => true, :on => :create)
# => Would run only when creating an object

validates(:name, :presence => {:on => :update})
# => Would run only when updating an object
```

See http://edgeguides.rubyonrails.org/active_record_validations_callbacks.html#on

Should fix https://github.com/couchrest/couchrest_model/issues/49
