### PR TITLE
#persisted? should be false after a document has been destroyed

### DIFF
--- a/lib/couchrest/model/base.rb
+++ b/lib/couchrest/model/base.rb
@@ -82,7 +82,7 @@ module CouchRest
       end
 
       def persisted?
-        !new?
+        !new? && !destroyed?
       end
 
       def to_key

--- a/lib/couchrest/model/casted_model.rb
+++ b/lib/couchrest/model/casted_model.rb
@@ -44,7 +44,7 @@ module CouchRest::Model
     alias :new_record? :new?
 
     def persisted?
-      !new?
+      !new? && !destroyed?
     end
 
     # The to_param method is needed for rails to generate resourceful routes.

--- a/spec/unit/base_spec.rb
+++ b/spec/unit/base_spec.rb
@@ -110,14 +110,22 @@ describe "Model Base" do
     describe "#persisted?" do
       context "when the document is new" do
         it "returns false" do
-          @obj.persisted?.should == false
+          @obj.persisted?.should be_false
         end
       end
 
       context "when the document is not new" do
         it "returns id" do
           @obj.save
-          @obj.persisted?.should == true 
+          @obj.persisted?.should be_true 
+        end
+      end
+      
+      context "when the document is destroyed" do
+        it "returns false" do
+          @obj.save
+          @obj.destroy
+          @obj.persisted?.should be_false
         end
       end
     end


### PR DESCRIPTION
According to the ActiveModel spec (and common sense), `#persisted?` should return `false` after a document has been destroyed. Right now it returns `true`.
