### PR TITLE
CastedModels also should not inherit from Hash

### DIFF
--- a/benchmarks/dirty.rb
+++ b/benchmarks/dirty.rb
@@ -6,7 +6,7 @@ require 'benchmark'
 $:.unshift(File.dirname(__FILE__) + '/../lib')
 require 'couchrest_model'
 
-class BenchmarkCasted < Hash
+class BenchmarkCasted < CouchRest::Document
   include CouchRest::Model::CastedModel
   
   property :name

--- a/lib/couchrest/model/casted_model.rb
+++ b/lib/couchrest/model/casted_model.rb
@@ -21,11 +21,16 @@ module CouchRest::Model
         end
       end
     end
+    
+    def self.included(base)
+      unless base < CouchRest::Document
+        raise "Casted models must inherit from CouchRest::Document"
+      end
+    end
 
-    def initialize(keys = {})
-      raise StandardError unless self.is_a? Hash
-      prepare_all_attributes(keys)
+    def initialize(attributes = {})
       super()
+      prepare_all_attributes(attributes)
     end
 
     def []= key, value
@@ -67,6 +72,13 @@ module CouchRest::Model
     end
     alias :attributes= :update_attributes_without_saving
 
+    def update_attributes(*args)
+      raise NoMethodError
+    end
+    
+    def save(*args)
+      raise NoMethodError
+    end
   end
 
 end

--- a/lib/couchrest/model/properties.rb
+++ b/lib/couchrest/model/properties.rb
@@ -168,7 +168,7 @@ module CouchRest
             # check if this property is going to casted
             type = options.delete(:type) || options.delete(:cast_as)
             if block_given?
-              type = Class.new(Hash) do
+              type = Class.new(CouchRest::Document) do
                 include CastedModel
               end
               if block.arity == 1 # Traditional, with options

--- a/spec/fixtures/models/cat.rb
+++ b/spec/fixtures/models/cat.rb
@@ -1,5 +1,5 @@
 
-class CatToy < Hash
+class CatToy < CouchRest::Document
   include ::CouchRest::Model::CastedModel
 
   property :name

--- a/spec/fixtures/models/membership.rb
+++ b/spec/fixtures/models/membership.rb
@@ -1,4 +1,4 @@
-class Membership < Hash
+class Membership < CouchRest::Document
   include CouchRest::Model::CastedModel
 
 end

--- a/spec/fixtures/models/person.rb
+++ b/spec/fixtures/models/person.rb
@@ -1,6 +1,6 @@
 require 'cat'
 
-class Person < Hash
+class Person < CouchRest::Document
   include ::CouchRest::Model::CastedModel
   property :pet, Cat
   property :name, [String]

--- a/spec/fixtures/models/question.rb
+++ b/spec/fixtures/models/question.rb
@@ -1,4 +1,4 @@
-class Question < Hash
+class Question < CouchRest::Document
   include ::CouchRest::Model::CastedModel
   
   property :q

--- a/spec/unit/casted_model_spec.rb
+++ b/spec/unit/casted_model_spec.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 require "spec_helper"
 
-class WithCastedModelMixin < Hash
+class WithCastedModelMixin < CouchRest::Document
   include CouchRest::Model::CastedModel
   property :name
   property :no_value
@@ -22,7 +22,7 @@ class DummyModel < CouchRest::Model::Base
   end
 end
 
-class WithCastedCallBackModel < Hash
+class WithCastedCallBackModel < CouchRest::Document
   include CouchRest::Model::CastedModel
   property :name
   property :run_before_validation
@@ -46,11 +46,11 @@ end
 
 describe CouchRest::Model::CastedModel do
 
-  describe "A non hash class including CastedModel" do
+  describe "A non CouchRest::Document class including CastedModel" do
     it "should fail raising and include error" do
       lambda do
-        class NotAHashButWithCastedModelMixin
-          include CouchRest::CastedModel
+        class NotACouchRestModelButWithCastedModelMixin
+          include CouchRest::Model::CastedModel
           property :name
         end
 

--- a/spec/unit/dirty_spec.rb
+++ b/spec/unit/dirty_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-class WithCastedModelMixin < Hash
+class WithCastedModelMixin < CouchRest::Document
   include CouchRest::Model::CastedModel
   property :name
   property :details, Object, :default => {}


### PR DESCRIPTION
_Why not???!%#$%_, you ask incredulously.
1. For the sake of consistency with the recent changes to CouchRest::Model::Base
2. Real-world: Rails will misinterpret a casted model as an options hash when you use `fields_for`

I don't intend this patch to be applied, but I wanted to include it with this issue because it works for me, and it passes the test suite. Basically, as Sam suggested to me, you just inherit from CouchRest::Document instead of Hash, and then with a small change to `CouchRest::Model::CastedModel#initialize` (see diff), it works.

It's not elegant, mostly because CouchRest::Document provides persistence features that don't make sense for casted models (I overrode `#update_attributes` and `#save` to always raise an error, since these shouldn't be called). But it's something to chew on.

By the way, even if CastedModel stays the same, there's a small bug to fix in the test suite: in [this test](https://github.com/couchrest/couchrest_model/blob/master/spec/unit/casted_model_spec.rb#L49), I think the include statement should be `include CouchRest::Model::CastedModel`. The test passes because it's expecting an error, but this is not the error it's expecting.

-Chase
