### PR TITLE
Tell contextual validations specs which database to use

### DIFF
--- a/spec/fixtures/models/base.rb
+++ b/spec/fixtures/models/base.rb
@@ -85,11 +85,13 @@ end
 
 # Following two fixture classes have __intentionally__ diffent syntax for setting the validation context
 class WithContextualValidationOnCreate < CouchRest::Model::Base
+  use_database TEST_SERVER.default_database
   property(:name, String)
   validates(:name, :presence => {:on => :create})
 end
 
 class WithContextualValidationOnUpdate < CouchRest::Model::Base
+  use_database TEST_SERVER.default_database
   property(:name, String)
   validates(:name, :presence => true, :on => :update)
 end


### PR DESCRIPTION
On my machine, `spec/unit/persistence_spec.rb` lines `360` and `370` failed, trying to use the '/couchrest' database. Setting them to use this test database fixes the issue for me.
