### PR TITLE
#view method works when auto_update_design_doc is disabled

### DIFF
--- a/lib/couchrest/model/designs.rb
+++ b/lib/couchrest/model/designs.rb
@@ -58,10 +58,11 @@ module CouchRest
           self.model = model
         end
 
-        # Define a view and generate a method that will provide a new 
-        # View instance when requested.
+        # Generate a method that will provide a new View instance when
+        # requested.  This will also define the view in CouchDB unless
+        # auto_update_design_doc is disabled.
         def view(name, opts = {})
-          View.create(model, name, opts)
+          View.create(model, name, opts) if model.auto_update_design_doc
           create_view_method(name)
         end
 

--- a/spec/couchrest/designs_spec.rb
+++ b/spec/couchrest/designs_spec.rb
@@ -84,7 +84,23 @@ describe "Design" do
         @object.should_receive(:create_view_method).with('test')
         @object.view('test')
       end
+    end
 
+    context "for model with auto_update_design_doc disabled " do 
+      class ::DesignModelAutoUpdateDesignDocDisabled < ::CouchRest::Model::Base
+        self.auto_update_design_doc = false
+      end
+
+      describe "#view" do 
+        before :each do
+          @object = @klass.new(DesignModelAutoUpdateDesignDocDisabled)
+        end
+
+        it "does not attempt to create view" do 
+          CouchRest::Model::Designs::View.should_not_receive(:create)
+          @object.view('test')
+        end
+      end
     end
 
     describe "#filter" do


### PR DESCRIPTION
Currently only complete view definitions work with `auto_update_design_doc` disabled.  For example, the following fails because there is not enough information to build the view.

```
design do
  view :active_by_owner_id
end
```

However, when you have `auto_update_design_doc` disabled the view will not be built automatically so that additional information is unnecessary.

The code in this branch just skips trying to create the view when `auto_update_design_doc` is disabled so that the above code works as expected. (Ie, creates a view accessor method for the existing view of that name.)
