### PR TITLE
Fix broken tests for a fresh bundle with ruby 1.9.3.

### DIFF
--- a/lib/couchrest/model/base.rb
+++ b/lib/couchrest/model/base.rb
@@ -100,6 +100,10 @@ module CouchRest
         new? ? nil : [id]
       end
 
+      def to_partial_path
+        @_to_partial_path ||= self.class.name.demodulize.underscore
+      end
+
       alias :to_param :id
       alias :new_record? :new?
       alias :new_document? :new?

--- a/lib/couchrest/model/typecast.rb
+++ b/lib/couchrest/model/typecast.rb
@@ -123,7 +123,7 @@ module CouchRest
 
         # Creates a Date instance from a Hash with keys :year, :month, :day
         def typecast_hash_to_date(value)
-          Date.new(*extract_time(value)[0, 3])
+          Date.new(*extract_time(value)[0, 3].map(&:to_i))
         end
 
         # Creates a Time instance from a Hash with keys :year, :month, :day,

--- a/spec/unit/design_doc_spec.rb
+++ b/spec/unit/design_doc_spec.rb
@@ -193,10 +193,17 @@ describe CouchRest::Model::DesignDoc do
               view :by_name
             end
             property :name, String
+
+            def self.reload_design_doc
+              @design_doc = nil
+            end
           end
         KLASS
 
-        class_name.constantize
+        new_model = class_name.constantize
+
+        new_model.reload_design_doc
+        new_model
       }
 
       it "will not update stored design doc if view changed" do

--- a/spec/unit/dirty_spec.rb
+++ b/spec/unit/dirty_spec.rb
@@ -35,9 +35,11 @@ describe "Dirty" do
 
     it "should return changes on an attribute" do
       @card = Card.new(:first_name => "matt")
+      @card.first_name_changed?.should be_true
+      @card.changes.should == { "first_name" => [nil, "matt"] }
       @card.first_name = "andrew"
       @card.first_name_changed?.should be_true
-      @card.changes.should == { "first_name" => ["matt", "andrew"] }
+      @card.changes.should == { "first_name" => [nil, "andrew"] }
     end
 
   end

--- a/spec/unit/inherited_spec.rb
+++ b/spec/unit/inherited_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 class PlainParent
-  class_inheritable_accessor :foo
+  class_attribute :foo
   self.foo = :bar
 end
 
@@ -9,7 +9,7 @@ class PlainChild < PlainParent
 end
 
 class ExtendedParent < CouchRest::Model::Base
-  class_inheritable_accessor :foo
+  class_attribute :foo
   self.foo = :bar
 end
 


### PR DESCRIPTION
This includes activemodel 3.2 support.
