### PR TITLE
Use backwards compatible hash on design doc spec

### DIFF
--- a/spec/unit/design_doc_spec.rb
+++ b/spec/unit/design_doc_spec.rb
@@ -220,7 +220,7 @@ describe CouchRest::Model::DesignDoc do
       end
 
       it "is able to use predefined views" do 
-        model_class.by_name(key: "special").all
+        model_class.by_name(:key => "special").all
       end
     end
   end


### PR DESCRIPTION
Taking care of #144
