### PR TITLE
Implements to_sym for CouchRest::Model::Property

### DIFF
--- a/lib/couchrest/model/property.rb
+++ b/lib/couchrest/model/property.rb
@@ -19,6 +19,10 @@ module CouchRest::Model
     def to_s
       name
     end
+    
+    def to_sym
+      @_sym_name ||= name.to_sym
+    end
 
     # Cast the provided value using the properties details.
     def cast(parent, value)

--- a/spec/unit/property_spec.rb
+++ b/spec/unit/property_spec.rb
@@ -393,6 +393,12 @@ describe "Property Class" do
     property.to_s.should eql('test')
   end
 
+  it "should provide name as a symbol" do 
+    property = CouchRest::Model::Property.new(:test, String)
+    property.name.to_sym.should eql(:test)
+    property.to_sym.should eql(:test)
+  end
+
   it "should provide class from type" do
     property = CouchRest::Model::Property.new(:test, String)
     property.type_class.should eql(String)


### PR DESCRIPTION
Should probably have to_sym as well as to_s, since about half the population prefers one and the other half prefers the other.
