### PR TITLE
follow Kaminari 0.14.0 API change: num_pages  =>  total_pages

### DIFF
--- a/lib/couchrest/model/designs/view.rb
+++ b/lib/couchrest/model/designs/view.rb
@@ -371,9 +371,10 @@ module CouchRest
           query[:limit]
         end
 
-        def num_pages
+        def total_pages
           (total_count.to_f / limit_value).ceil
         end
+        alias num_pages total_pages
 
         def current_page
           (offset_value / limit_value) + 1

--- a/spec/unit/designs/view_spec.rb
+++ b/spec/unit/designs/view_spec.rb
@@ -719,6 +719,15 @@ describe "Design View" do
           end
         end
 
+        describe "#total_pages" do
+          it "should use total_count and limit_value" do
+            @obj.should_receive(:total_count).and_return(200)
+            @obj.should_receive(:limit_value).and_return(25)
+            @obj.total_pages.should eql(8)
+          end
+        end
+
+        # `num_pages` aliases to `total_pages` for compatibility for Kaminari '< 0.14'
         describe "#num_pages" do
           it "should use total_count and limit_value" do
             @obj.should_receive(:total_count).and_return(200)
@@ -887,7 +896,7 @@ describe "Design View" do
       end
 
       it "should calculate number of pages" do
-        @view.num_pages.should eql(2)
+        @view.total_pages.should eql(2)
       end
       it "should return results from first page" do
         @view.all.first.name.should eql('Judith')
@@ -900,7 +909,7 @@ describe "Design View" do
 
       it "should allow overriding per page count" do
         @view = @view.per(10)
-        @view.num_pages.should eql(1)
+        @view.total_pages.should eql(1)
         @view.all.last.name.should eql('Vilma')
       end
     end


### PR DESCRIPTION
Hi.

We just released a new version of Kaminari gem (0.14.0), and we have changed the internal method name `num_pages` to `total_pages` since this version.
And consequently, Kaminari stopped working with CouchRest Model https://github.com/amatsuda/kaminari/issues/278

I'm sorry that I forgot to inform you before the gem release, but here's a PR.
