### PR TITLE
raise a couchrest specific error if connection to the database fails

### DIFF
--- a/lib/couchrest/model/connection.rb
+++ b/lib/couchrest/model/connection.rb
@@ -33,6 +33,10 @@ module CouchRest
           else
             db
           end
+        rescue RestClient::Unauthorized,
+          Errno::EHOSTUNREACH,
+          Errno::ECONNREFUSED => e
+          raise CouchRest::Model::ConnectionFailed.new(e.to_s)
         end
 
         protected

--- a/lib/couchrest/model/errors.rb
+++ b/lib/couchrest/model/errors.rb
@@ -20,6 +20,13 @@ module CouchRest
       end
     end
 
+    # Raised when the connection to the couch server can not be established.
+    #
+    # The message will contain the corresponding error message from the
+    # underlying error.
+    #
+    class ConnectionFailed < CouchRestModelError; end
+
     class DocumentNotFound < Errors::CouchRestModelError; end
   end
 end


### PR DESCRIPTION
The underlying Errno errors are very generic. It's not clear from the logs that the connection to the couchdb failed. Also hard to catch these because they are all different if the connection fails for different reasons.
