### PR TITLE
Goodbye, bad whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ $ rails generate couchrest_model:config
 $ rails generate model person --orm=couchrest_model
 ```
 
-## General Usage 
+## General Usage
 
 ```ruby
 require 'couchrest_model'

--- a/THANKS.md
+++ b/THANKS.md
@@ -2,7 +2,7 @@ CouchRest THANKS
 =====================
 
 CouchRest was originally developed by J. Chris Anderson <jchris@grabb.it>
-and a number of other contributors. Many people further contributed to 
+and a number of other contributors. Many people further contributed to
 CouchRest by reporting problems, suggesting various improvements or submitting
 changes. A list of these people is included below.
 
@@ -15,7 +15,7 @@ changes. A list of these people is included below.
  * [Marcos Tapajós](http://tapajos.me)
  * [Sam Lown](http://github.com/samlown)
  * [Will Leinweber](http://github.com/will)
- 
+
 Patches are welcome. The primary source for this software project is [on Github](http://github.com/couchrest/couchrest)
 
 A lot of people have active forks - thank you all - even the patches I don't end up using are helpful.

--- a/benchmarks/dirty.rb
+++ b/benchmarks/dirty.rb
@@ -8,7 +8,7 @@ require 'couchrest_model'
 
 class BenchmarkCasted < Hash
   include CouchRest::Model::CastedModel
-  
+
   property :name
 end
 
@@ -86,11 +86,11 @@ def run_benchmark
     if ENV['BENCHMARK_DB']
       # db writing
       x.report("write changed record to db") do
-        db_n.times { |i| b.string = "test#{i}"; b.save }  
+        db_n.times { |i| b.string = "test#{i}"; b.save }
       end
 
       x.report("write unchanged record to db") do
-        db_n.times { b.save }  
+        db_n.times { b.save }
       end
 
       # db reading

--- a/history.md
+++ b/history.md
@@ -86,10 +86,10 @@
   * Support typecasting `Symbol`
   * Added `:array` option to properties
   * Typecasting Dates, Times, and Booleans, with invalid values returns nil
-  
+
   * API Breaking Changes
     * Properties with blocks are now singular unless the `array: true` option is passed.
-  
+
 
 ## 1.2.0.beta - 2012-06-08
 
@@ -217,7 +217,7 @@ Notes:
 ## CouchRest Model 1.0.0.beta8
 
 * Major enhancements
-	* Added model generator
+  * Added model generator
 
 * Minor enhancements
   * Raise error on adding objects to "collection_of" without an id

--- a/lib/couchrest/model/associations.rb
+++ b/lib/couchrest/model/associations.rb
@@ -11,14 +11,14 @@ module CouchRest
         # An attribute will be created matching the name of the attribute
         # with '_id' on the end, or the foreign key (:foreign_key) provided.
         #
-        # Searching for the assocated object is performed using a string 
+        # Searching for the assocated object is performed using a string
         # (:proxy) to be evaulated in the context of the owner. Typically
         # this will be set to the class name (:class_name), or determined
         # automatically if the owner belongs to a proxy object.
         #
         # If the association owner is proxied by another model, than an attempt will
         # be made to automatically determine the correct place to request
-        # the documents. Typically, this is a method with the pluralized name of the 
+        # the documents. Typically, this is a method with the pluralized name of the
         # association inside owner's owner, or proxy.
         #
         # For example, imagine a company acts as a proxy for invoices and clients.
@@ -28,7 +28,7 @@ module CouchRest
         #
         #    self.company.clients
         #
-        # If the name of the collection proxy is not the pluralized assocation name, 
+        # If the name of the collection proxy is not the pluralized assocation name,
         # it can be set with the :proxy_name option.
         #
         def belongs_to(attrib, *options)

--- a/lib/couchrest/model/base.rb
+++ b/lib/couchrest/model/base.rb
@@ -19,7 +19,7 @@ module CouchRest
       include Designs
       include CastedBy
       include Dirty
-      
+
 
       def self.subclasses
         @subclasses ||= []
@@ -76,13 +76,13 @@ module CouchRest
       alias :new_record? :new?
       alias :new_document? :new?
 
-      # Compare this model with another by confirming to see 
+      # Compare this model with another by confirming to see
       # if the IDs and their databases match!
       #
-      # Camparison of the database is required in case the 
+      # Camparison of the database is required in case the
       # model has been proxied or loaded elsewhere.
       #
-      # A Basic CouchRest document will only ever compare using 
+      # A Basic CouchRest document will only ever compare using
       # a Hash comparison on the attributes.
       def == other
         return false unless other.is_a?(Base)

--- a/lib/couchrest/model/designs.rb
+++ b/lib/couchrest/model/designs.rb
@@ -30,7 +30,7 @@ module CouchRest
         # Adding a prefix allows you to associate multiple design documents with the same
         # model. This is useful if you'd like to split your designs into seperate
         # use cases; one for regular search functions and a second for stats for example.
-        # 
+        #
         #    # Create a design doc with id _design/Cats
         #    design do
         #      view :by_name
@@ -100,7 +100,7 @@ module CouchRest
         end
 
         def prepare_source_paths(options)
-          
+
         end
 
       end

--- a/lib/couchrest/model/extended_attachments.rb
+++ b/lib/couchrest/model/extended_attachments.rb
@@ -12,7 +12,7 @@ module CouchRest
       rescue ArgumentError
         raise ArgumentError, 'You must specify :file and :name'
       end
-      
+
       # return all attachments
       def attachments
         self['_attachments'] ||= {}
@@ -51,15 +51,15 @@ module CouchRest
         return unless has_attachment?(attachment_name)
         "#{database.root}/#{self.id}/#{attachment_name}"
       end
-      
+
       # returns URI to fetch the attachment from
       def attachment_uri(attachment_name)
         return unless has_attachment?(attachment_name)
         "#{database.uri}/#{self.id}/#{attachment_name}"
       end
-      
+
       private
-      
+
         def get_mime_type(path)
           return nil if path.nil?
           type = ::MIME::Types.type_for(path)
@@ -75,7 +75,7 @@ module CouchRest
             'data'         => args[:file].read
           }
         end
-      
+
     end # module ExtendedAttachments
   end
 end

--- a/lib/couchrest/model/properties.rb
+++ b/lib/couchrest/model/properties.rb
@@ -100,7 +100,7 @@ module CouchRest
             multi_parameter_attributes << [ key, value ]
             false
           elsif self.respond_to?("#{key}=")
-            self.send("#{key}=", value) 
+            self.send("#{key}=", value)
           elsif mass_assign || mass_assign_any_attribute
             self[key] = value
           end
@@ -131,7 +131,7 @@ module CouchRest
       def execute_callstack_for_multiparameter_attributes(callstack, hash)
         callstack.each do |name, values_with_empty_parameters|
           if self.respond_to?("#{name}=")
-            casted_attrib = send("#{name}=", values_with_empty_parameters) 
+            casted_attrib = send("#{name}=", values_with_empty_parameters)
             unless casted_attrib.is_a?(Hash)
               hash.reject { |key, value| key.include?(name.to_s)}
             end
@@ -177,7 +177,7 @@ module CouchRest
 
         # Automatically set <tt>updated_at</tt> and <tt>created_at</tt> fields
         # on the document whenever saving occurs.
-        # 
+        #
         # These properties are casted as Time objects, so they should always
         # be set to UTC.
         def timestamps!

--- a/lib/couchrest/model/property.rb
+++ b/lib/couchrest/model/property.rb
@@ -18,7 +18,7 @@ module CouchRest::Model
     def to_s
       name
     end
-    
+
     def to_sym
       @_sym_name ||= name.to_sym
     end
@@ -65,7 +65,7 @@ module CouchRest::Model
     end
 
     # Initialize a new instance of a property's type ready to be
-    # used. If a proc is defined for the init method, it will be used instead of 
+    # used. If a proc is defined for the init method, it will be used instead of
     # a normal call to the class.
     def build(*args)
       raise StandardError, "Cannot build property without a class" if @type.nil?

--- a/lib/couchrest/model/support/couchrest_database.rb
+++ b/lib/couchrest/model/support/couchrest_database.rb
@@ -1,6 +1,6 @@
 #
 # Extend CouchRest's normal database delete! method to ensure any caches are
-# also emptied. Given that this is a rare event, and the consequences are not 
+# also emptied. Given that this is a rare event, and the consequences are not
 # very severe, we just completely empty the cache.
 #
 module CouchRest::Model

--- a/lib/couchrest/model/validations/casted_model.rb
+++ b/lib/couchrest/model/validations/casted_model.rb
@@ -2,7 +2,6 @@ module CouchRest
   module Model
     module Validations
       class CastedModelValidator < ActiveModel::EachValidator
-        
         def validate_each(document, attribute, value)
           values = value.is_a?(Array) ? value : [value]
           return if values.collect {|doc| doc.nil? || doc.valid? }.all?

--- a/lib/rails/generators/couchrest_model.rb
+++ b/lib/rails/generators/couchrest_model.rb
@@ -5,12 +5,10 @@ require 'couchrest_model'
 module CouchrestModel
   module Generators
     class Base < Rails::Generators::NamedBase #:nodoc:
-      
       # Set the current directory as base for the inherited generators.
       def self.base_root
         File.dirname(__FILE__)
       end
-      
     end
   end
 end

--- a/lib/rails/generators/couchrest_model/model/model_generator.rb
+++ b/lib/rails/generators/couchrest_model/model/model_generator.rb
@@ -13,7 +13,7 @@ module CouchrestModel
         return if class_path.empty?
         template 'module.rb', File.join('app/models', "#{class_path.join('/')}.rb") if behavior == :invoke
       end
-      
+
       hook_for :test_framework
 
       protected

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -57,7 +57,7 @@ class Basic < CouchRest::Model::Base
 end
 
 def reset_test_db!
-  DB.recreate! rescue nil 
+  DB.recreate! rescue nil
   # Reset the Design Cache
   Thread.current[:couchrest_design_cache] = {}
   DB

--- a/spec/unit/assocations_spec.rb
+++ b/spec/unit/assocations_spec.rb
@@ -29,7 +29,7 @@ describe "Assocations" do
       o = SaleInvoice.merge_assoc_opts(:cat)
       expect(o[:proxy]).to eql('self.company.cats')
     end
-    
+
   end
 
   describe "of type belongs to" do

--- a/spec/unit/attachment_spec.rb
+++ b/spec/unit/attachment_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe "Model attachments" do
-  
+
   describe "#has_attachment?" do
     before(:each) do
       reset_test_db!
@@ -11,32 +11,32 @@ describe "Model attachments" do
       @attachment_name = 'my_attachment'
       @obj.create_attachment(:file => @file, :name => @attachment_name)
     end
-  
+
     it 'should return false if there is no attachment' do
       expect(@obj.has_attachment?('bogus')).to be_falsey
     end
-  
+
     it 'should return true if there is an attachment' do
       expect(@obj.has_attachment?(@attachment_name)).to be_truthy
     end
-  
+
     it 'should return true if an object with an attachment is reloaded' do
       expect(@obj.save).to be_truthy
       reloaded_obj = Basic.get(@obj.id)
       expect(reloaded_obj.has_attachment?(@attachment_name)).to be_truthy
     end
-  
+
     it 'should return false if an attachment has been removed' do
       @obj.delete_attachment(@attachment_name)
       expect(@obj.has_attachment?(@attachment_name)).to be_falsey
     end
-    
+
     it 'should return false if an attachment has been removed and reloaded' do
       @obj.delete_attachment(@attachment_name)
       reloaded_obj = Basic.get(@obj.id)
       expect(reloaded_obj.has_attachment?(@attachment_name)).to be_falsey
     end
-    
+
   end
 
   describe "creating an attachment" do
@@ -48,29 +48,29 @@ describe "Model attachments" do
       @attachment_name = 'my_attachment'
       @content_type = 'media/mp3'
     end
-  
+
     it "should create an attachment from file with an extension" do
       @obj.create_attachment(:file => @file_ext, :name => @attachment_name)
       expect(@obj.save).to be_truthy
       reloaded_obj = Basic.get(@obj.id)
       expect(reloaded_obj.attachments[@attachment_name]).not_to be_nil
     end
-  
+
     it "should create an attachment from file without an extension" do
       @obj.create_attachment(:file => @file_no_ext, :name => @attachment_name)
       expect(@obj.save).to be_truthy
       reloaded_obj = Basic.get(@obj.id)
       expect(reloaded_obj.attachments[@attachment_name]).not_to be_nil
     end
-  
+
     it 'should raise ArgumentError if :file is missing' do
       expect{ @obj.create_attachment(:name => @attachment_name) }.to raise_error(ArgumentError, /:file/)
     end
-  
+
     it 'should raise ArgumentError if :name is missing' do
       expect{ @obj.create_attachment(:file => @file_ext) }.to raise_error(ArgumentError, /:name/)
     end
-  
+
     it 'should set the content-type if passed' do
       @obj.create_attachment(:file => @file_ext, :name => @attachment_name, :content_type => @content_type)
       expect(@obj.attachments[@attachment_name]['content_type']).to eq(@content_type)
@@ -78,14 +78,14 @@ describe "Model attachments" do
 
     it "should detect the content-type automatically" do
       @obj.create_attachment(:file => File.open(FIXTURE_PATH + '/attachments/couchdb.png'), :name => "couchdb.png")
-      expect(@obj.attachments['couchdb.png']['content_type']).to eq("image/png") 
+      expect(@obj.attachments['couchdb.png']['content_type']).to eq("image/png")
     end
 
     it "should use name to detect the content-type automatically if no file" do
       file = File.open(FIXTURE_PATH + '/attachments/couchdb.png')
       allow(file).to receive(:path).and_return("badfilname")
       @obj.create_attachment(:file => File.open(FIXTURE_PATH + '/attachments/couchdb.png'), :name => "couchdb.png")
-      expect(@obj.attachments['couchdb.png']['content_type']).to eq("image/png") 
+      expect(@obj.attachments['couchdb.png']['content_type']).to eq("image/png")
     end
 
   end
@@ -100,11 +100,11 @@ describe "Model attachments" do
       @file.rewind
       @content_type = 'media/mp3'
     end
-  
+
     it 'should read an attachment that exists' do
       expect(@obj.read_attachment(@attachment_name)).to eq(@file.read)
     end
-  
+
     it 'should update an attachment that exists' do
       file = File.open(FIXTURE_PATH + '/attachments/README')
       expect(@file).not_to eq(file)
@@ -115,14 +115,14 @@ describe "Model attachments" do
       expect(reloaded_obj.read_attachment(@attachment_name)).not_to eq(@file.read)
       expect(reloaded_obj.read_attachment(@attachment_name)).to eq(file.read)
     end
-  
+
     it 'should set the content-type if passed' do
       file = File.open(FIXTURE_PATH + '/attachments/README')
       expect(@file).not_to eq(file)
       @obj.update_attachment(:file => file, :name => @attachment_name, :content_type => @content_type)
       expect(@obj.attachments[@attachment_name]['content_type']).to eq(@content_type)
     end
-  
+
     it 'should delete an attachment that exists' do
       @obj.delete_attachment(@attachment_name)
       @obj.save
@@ -138,15 +138,15 @@ describe "Model attachments" do
       @obj.create_attachment(:file => @file, :name => @attachment_name)
       expect(@obj.save).to be_truthy
     end
-  
+
     it 'should return nil if attachment does not exist' do
       expect(@obj.attachment_url('bogus')).to be_nil
     end
-  
+
     it 'should return the attachment URL as specified by CouchDB HttpDocumentApi' do
       expect(@obj.attachment_url(@attachment_name)).to eq("#{Basic.database}/#{@obj.id}/#{@attachment_name}")
     end
-    
+
     it 'should return the attachment URI' do
       expect(@obj.attachment_uri(@attachment_name)).to eq("#{Basic.database.uri}/#{@obj.id}/#{@attachment_name}")
     end
@@ -160,17 +160,17 @@ describe "Model attachments" do
       @obj.create_attachment(:file => @file, :name => @attachment_name)
       expect(@obj.save).to be_truthy
     end
-  
+
     it 'should return an empty Hash when document does not have any attachment' do
       new_obj = Basic.new
       expect(new_obj.save).to be_truthy
       expect(new_obj.attachments).to eq({})
     end
-  
+
     it 'should return a Hash with all attachments' do
       @file.rewind
       expect(@obj.attachments).to eq({ @attachment_name =>{ "data" => "PCFET0NUWVBFIGh0bWw+CjxodG1sPgogIDxoZWFkPgogICAgPHRpdGxlPlRlc3Q8L3RpdGxlPgogIDwvaGVhZD4KICA8Ym9keT4KICAgIDxwPgogICAgICBUZXN0CiAgICA8L3A+CiAgPC9ib2R5Pgo8L2h0bWw+Cg==", "content_type" => "text/html"}})
     end
-  
+
   end
 end

--- a/spec/unit/base_spec.rb
+++ b/spec/unit/base_spec.rb
@@ -2,23 +2,23 @@
 require "spec_helper"
 
 describe "Model Base" do
-  
+
   before(:each) do
     @obj = WithDefaultValues.new
   end
-  
+
   describe "instance database connection" do
     it "should use the default database" do
       expect(@obj.database.name).to eq('couchrest-model-test')
     end
-    
+
     it "should override the default db" do
       @obj.database = TEST_SERVER.database!('couchrest-extendedmodel-test')
       expect(@obj.database.name).to eql 'couchrest-extendedmodel-test'
       @obj.database.delete!
     end
   end
-  
+
   describe "a new model" do
     it "should be a new document" do
       @obj = Basic.new
@@ -38,7 +38,7 @@ describe "Model Base" do
       expect(@obj.database).to eql('database')
     end
 
-    it "should support initialization block" do 
+    it "should support initialization block" do
       @obj = Basic.new {|b| b.database = 'database'}
       expect(@obj.database).to eql('database')
     end
@@ -84,7 +84,7 @@ describe "Model Base" do
 
   describe "ActiveModel compatability Basic" do
 
-    before(:each) do 
+    before(:each) do
       @obj = Basic.new(nil)
     end
 
@@ -128,10 +128,10 @@ describe "Model Base" do
       context "when the document is not new" do
         it "returns id" do
           @obj.save
-          expect(@obj.persisted?).to be_truthy 
+          expect(@obj.persisted?).to be_truthy
         end
       end
-      
+
       context "when the document is destroyed" do
         it "returns false" do
           @obj.save
@@ -234,7 +234,7 @@ describe "Model Base" do
       @art.attributes = {'date' => Time.now, :title => "something else"}
       expect(@art['title']).to eql("something else")
     end
-    
+
     it "should not flip out if an attribute= method is missing and ignore it" do
       expect {
         @art.attributes = {'slug' => "new-slug", :title => "super danger"}
@@ -244,7 +244,7 @@ describe "Model Base" do
 
     #it "should not change other attributes if there is an error" do
     #  lambda {
-    #    @art.update_attributes_without_saving('slug' => "new-slug", :title => "super danger")        
+    #    @art.update_attributes_without_saving('slug' => "new-slug", :title => "super danger")
     #  }.should raise_error
     #  @art['title'].should == "big bad danger"
     #end
@@ -273,13 +273,13 @@ describe "Model Base" do
     it "should have the default false value explicitly assigned" do
       expect(@obj.default_false).to eq(false)
     end
-    
+
     it "should automatically call a proc default at initialization" do
       expect(@obj.set_by_proc).to be_an_instance_of(Time)
       expect(@obj.set_by_proc).to eq(@obj.set_by_proc)
       expect(@obj.set_by_proc.utc).to be < Time.now.utc
     end
-    
+
     it "should let you overwrite the default values" do
       obj = WithDefaultValues.new(:preset => 'test')
       obj.preset = 'test'
@@ -292,12 +292,12 @@ describe "Model Base" do
       another = WithDefaultValues.new
       expect(another.preset).to eq({:right => 10, :top_align => false})
     end
-    
+
     it "should work with a default empty array" do
       obj = WithDefaultValues.new(:tags => ['spec'])
       expect(obj.tags).to eq(['spec'])
     end
-    
+
     it "should set default value of read-only property" do
       obj = WithDefaultValues.new
       expect(obj.read_only_with_default).to eq('generic')
@@ -315,7 +315,7 @@ describe "Model Base" do
       expect(obj.tags).to eq(['spec'])
     end
   end
-  
+
   describe "a doc with template values (CR::Model spec)" do
     before(:all) do
       WithTemplateAndUniqueID.all.map{|o| o.destroy}
@@ -336,8 +336,7 @@ describe "Model Base" do
       expect(tmpl2_reloaded.preset).to eq('not_value')
     end
   end
-  
-  
+
   describe "finding all instances of a model" do
     before(:all) do
       WithTemplateAndUniqueID.all.map{|o| o.destroy}
@@ -348,11 +347,11 @@ describe "Model Base" do
       WithTemplateAndUniqueID.new('slug' => '4').save
     end
     it "should find all" do
-      rs = WithTemplateAndUniqueID.all 
+      rs = WithTemplateAndUniqueID.all
       expect(rs.length).to eq(4)
     end
   end
-  
+
   describe "counting all instances of a model" do
     before(:each) do
       reset_test_db!
@@ -369,9 +368,9 @@ describe "Model Base" do
       expect(WithTemplateAndUniqueID.count).to eq(3)
     end
   end
-  
+
   describe "finding the first instance of a model" do
-    before(:each) do      
+    before(:each) do
       reset_test_db!
       WithTemplateAndUniqueID.new('slug' => '1').save
       WithTemplateAndUniqueID.new('slug' => '2').save
@@ -388,7 +387,7 @@ describe "Model Base" do
     end
   end
 
-  
+
   describe "getting a model with a subobject field" do
     before(:all) do
       course_doc = {
@@ -411,7 +410,7 @@ describe "Model Base" do
       expect(@course['ends_at']).to eq(Time.parse("2008/12/19 13:00:00 +0800"))
     end
   end
-  
+
   describe "timestamping" do
     before(:each) do
       oldart = Article.get "saving-this" rescue nil
@@ -419,7 +418,7 @@ describe "Model Base" do
       @art = Article.new(:title => "Saving this")
       @art.save
     end
-    
+
     it "should define the updated_at and created_at getters and set the values" do
       @obj.save
       json = @obj.to_json
@@ -429,15 +428,15 @@ describe "Model Base" do
       expect(obj.updated_at).to be_an_instance_of(Time)
       expect(obj.created_at.to_s).to eq(@obj.updated_at.to_s)
     end
-    
+
     it "should not change created_at on update" do
-      2.times do 
+      2.times do
         expect do
           @art.save
         end.not_to change(@art, :created_at)
       end
     end
-     
+
     it "should set the time on create" do
       expect(Time.now - @art.created_at).to be < 2
       foundart = Article.get @art.id
@@ -450,7 +449,7 @@ describe "Model Base" do
       expect(@art.created_at).to be < @art.updated_at
     end
   end
-  
+
   describe "getter and setter methods" do
     it "should try to call the arg= method before setting :arg in the hash" do
       @doc = WithGetterAndSetterMethods.new(:arg => "foo")
@@ -465,35 +464,35 @@ describe "Model Base" do
       reset_test_db!
       @cat = Cat.new(:name => 'Sockington')
     end
-    
+
     it "should not save if a nested casted model is invalid" do
       @cat.favorite_toy = CatToy.new
       expect(@cat).not_to be_valid
       expect(@cat.save).to be_falsey
       expect{@cat.save!}.to raise_error(/Validation Failed/)
     end
-    
+
     it "should save when nested casted model is valid" do
       @cat.favorite_toy = CatToy.new(:name => 'Squeaky')
       expect(@cat).to be_valid
       expect(@cat.save).to be_truthy
       expect{@cat.save!}.not_to raise_error
     end
-    
+
     it "should not save when nested collection contains an invalid casted model" do
       @cat.toys = [CatToy.new(:name => 'Feather'), CatToy.new]
       expect(@cat).not_to be_valid
       expect(@cat.save).to be_falsey
       expect{@cat.save!}.to raise_error(/Validation Failed/)
     end
-    
+
     it "should save when nested collection contains valid casted models" do
       @cat.toys = [CatToy.new(:name => 'feather'), CatToy.new(:name => 'ball-o-twine')]
       expect(@cat).to be_valid
       expect(@cat.save).to be_truthy
       expect{@cat.save!}.not_to raise_error
     end
-    
+
     it "should not fail if the nested casted model doesn't have validation" do
       Cat.property :trainer, Person
       Cat.validates_presence_of :name

--- a/spec/unit/casted_spec.rb
+++ b/spec/unit/casted_spec.rb
@@ -4,19 +4,19 @@ class Driver < CouchRest::Model::Base
   use_database DB
   # You have to add a casted_by accessor if you want to reach a casted extended doc parent
   attr_accessor :casted_by
-  
+
   property :name
 end
 
 class Car < CouchRest::Model::Base
   use_database DB
-  
+
   property :name
   property :driver, Driver
 end
 
 describe "casting an extended document" do
-  
+
   before(:each) do
     @driver = Driver.new(:name => 'Matt')
     @car    = Car.new(:name => 'Renault 306', :driver => @driver)
@@ -25,7 +25,7 @@ describe "casting an extended document" do
   it "should retain all properties of the casted attribute" do
     expect(@car.driver).to eq(@driver)
   end
-  
+
   it "should let the casted document know who casted it" do
     expect(@car.driver.casted_by).to eq(@car)
   end
@@ -37,16 +37,16 @@ describe "assigning a value to casted attribute after initializing an object" do
     @car    = Car.new(:name => 'Renault 306')
     @driver = Driver.new(:name => 'Matt')
   end
-  
+
   it "should not create an empty casted object" do
     expect(@car.driver).to be_nil
   end
-  
+
   it "should let you assign the value" do
     @car.driver = @driver
     expect(@car.driver.name).to eq('Matt')
   end
-  
+
   it "should cast attribute" do
     @car.driver = JSON.parse(@driver.to_json)
     expect(@car.driver).to be_instance_of(Driver)
@@ -65,7 +65,7 @@ describe "casting a model from parsed JSON" do
   it "should cast casted attribute" do
     expect(@new_car.driver).to be_instance_of(Driver)
   end
-  
+
   it "should retain all properties of the casted attribute" do
     expect(@new_car.driver).to eq(@driver)
   end

--- a/spec/unit/configuration_spec.rb
+++ b/spec/unit/configuration_spec.rb
@@ -18,13 +18,12 @@ describe CouchRest::Model::Configuration do
   end
 
   describe '.add_config' do
-    
     it "should add a class level accessor" do
       @class.add_config :foo_bar
       @class.foo_bar = 'foo'
       expect(@class.foo_bar).to eq('foo')
     end
-    
+
     ['foo', :foo, 45, ['foo', :bar]].each do |val|
       it "should be inheritable for a #{val.class}" do
         @class.add_config :foo_bar
@@ -40,14 +39,13 @@ describe CouchRest::Model::Configuration do
         expect(@class.foo_bar).to eq(val)
       end
     end
-    
-    
+
     it "should add an instance level accessor" do
       @class.add_config :foo_bar
       @class.foo_bar = 'foo'
       expect(@class.new.foo_bar).to eq('foo')
     end
-    
+
     it "should add a convenient in-class setter" do
       @class.add_config :foo_bar
       @class.foo_bar "monkey"
@@ -73,5 +71,4 @@ describe CouchRest::Model::Configuration do
       expect(cat.model_type_key).to eql('cat-type')
     end
   end
-
 end

--- a/spec/unit/designs/view_spec.rb
+++ b/spec/unit/designs/view_spec.rb
@@ -987,10 +987,7 @@ describe "Design View" do
         expect(obj.model).not_to receive(:get)
         expect(obj.doc).to be_nil
       end
-
-
     end
-
   end
 
 

--- a/spec/unit/designs_spec.rb
+++ b/spec/unit/designs_spec.rb
@@ -125,7 +125,7 @@ describe CouchRest::Model::Designs do
         doc = CouchRest::Document.new("_id" => "_design/#{id}")
         doc["language"] = "javascript"
         doc["views"] = {"all"     => {"map" => "function(doc) { if (doc['type'] == '#{id}') { emit(doc['_id'],1); } }"},
-                        "by_title" => {"map" => 
+                        "by_title" => {"map" =>
                                   "function(doc) {
                                      if ((doc['type'] == '#{id}') && (doc['title'] != null)) {
                                        emit(doc['title'], 1);
@@ -149,7 +149,6 @@ describe CouchRest::Model::Designs do
     describe "using views" do
 
       describe "to find a single item" do
-  
         before(:all) do
           reset_test_db!
           %w{aaa bbb ddd eee}.each do |title|
@@ -203,7 +202,7 @@ describe CouchRest::Model::Designs do
 
         before(:all) do
           reset_test_db!
-          @db = DB 
+          @db = DB
           %w{aaa bbb ddd eee}.each do |title|
             u = Unattached.new(:title => title)
             u.database = @db
@@ -272,7 +271,7 @@ describe CouchRest::Model::Designs do
         end
         it "should sort correctly" do
           articles = Article.by_user_id_and_date.all
-          expect(articles.collect{|a|a['user_id']}).to eq(['aaron', 'aaron', 'quentin', 
+          expect(articles.collect{|a|a['user_id']}).to eq(['aaron', 'aaron', 'quentin',
             'quentin'])
           expect(articles[1].title).to eq('not junk')
         end
@@ -282,10 +281,6 @@ describe CouchRest::Model::Designs do
           expect(articles[0].title).to eq("even more interesting")
         end
       end
-
-
     end
-
   end
-
 end

--- a/spec/unit/dirty_spec.rb
+++ b/spec/unit/dirty_spec.rb
@@ -5,7 +5,7 @@ class WithCastedModelMixin
   property :name
   property :details, Object, :default => {}
   property :casted_attribute, WithCastedModelMixin
-end 
+end
 
 class DirtyModel < CouchRest::Model::Base
   use_database DB

--- a/spec/unit/persistence_spec.rb
+++ b/spec/unit/persistence_spec.rb
@@ -44,13 +44,13 @@ describe CouchRest::Model::Persistence do
       expect(saved_obj.set_by_proc).to be_an_instance_of(Time)
     end
   end
- 
+
   describe "creating a model" do
 
     before(:each) do
       @sobj = Basic.new
     end
-   
+
     it "should accept true or false on save for validation" do
       expect(@sobj).to receive(:valid?)
       @sobj.save(true)
@@ -75,22 +75,22 @@ describe CouchRest::Model::Persistence do
       article = Article.create(:title => 'my test')
       expect(article.title).to eq('my test')
       expect(article).not_to be_new
-    end 
-    
+    end
+
     it "yields new instance to block before saving (#create)" do
       article = Article.create{|a| a.title = 'my create init block test'}
       expect(article.title).to eq('my create init block test')
       expect(article).not_to be_new
-    end 
+    end
 
     it "yields new instance to block before saving (#create!)" do
       article = Article.create{|a| a.title = 'my create bang init block test'}
       expect(article.title).to eq('my create bang init block test')
       expect(article).not_to be_new
-    end 
+    end
 
     it "should trigger the create callbacks" do
-      doc = WithCallBacks.create(:name => 'my other test') 
+      doc = WithCallBacks.create(:name => 'my other test')
       expect(doc.run_before_create).to be_truthy
       expect(doc.run_after_create).to be_truthy
       expect(doc.run_before_save).to be_truthy
@@ -104,23 +104,23 @@ describe CouchRest::Model::Persistence do
       @sobj = Basic.new
       expect(@sobj.save).to be_truthy
     end
-    
+
     it "should save the doc" do
       doc = Basic.get(@sobj.id)
       expect(doc['_id']).to eq(@sobj.id)
     end
-    
+
     it "should be set for resaving" do
       rev = @obj.rev
       @sobj['another-key'] = "some value"
       @sobj.save
       expect(@sobj.rev).not_to eq(rev)
     end
-    
+
     it "should set the id" do
       expect(@sobj.id).to be_an_instance_of(String)
     end
-    
+
     it "should set the type" do
       expect(@sobj[@sobj.model_type_key]).to eq('Basic')
     end
@@ -146,15 +146,15 @@ describe CouchRest::Model::Persistence do
     end
 
     describe "save!" do
-      
+
       before(:each) do
         @sobj = Card.new(:first_name => "Marcos", :last_name => "Tapajós")
       end
-      
+
       it "should return true if save the document" do
         expect(@sobj.save!).to be_truthy
       end
-      
+
       it "should raise error if don't save the document" do
         @sobj.first_name = nil
         expect { @sobj.save! }.to raise_error(CouchRest::Model::Errors::Validations)
@@ -162,25 +162,25 @@ describe CouchRest::Model::Persistence do
 
     end
   end
-  
+
   describe "saving a model with a unique_id configured" do
     before(:each) do
       @art = Article.new
       @old = Article.database.get('this-is-the-title') rescue nil
       Article.database.delete_doc(@old) if @old
     end
-    
+
     it "should be a new document" do
       expect(@art).to be_new
       expect(@art.title).to be_nil
     end
-    
+
     it "should require the title" do
       expect{@art.save}.to raise_error(/unique_id cannot be nil/)
       @art.title = 'This is the title'
       expect(@art.save).to be_truthy
     end
-    
+
     it "should not change the slug on update" do
       @art.title = 'This is the title'
       expect(@art.save).to be_truthy
@@ -188,20 +188,20 @@ describe CouchRest::Model::Persistence do
       expect(@art.save).to be_truthy
       expect(@art.slug).to eq('this-is-the-title')
     end
-    
+
     it "should raise an error when the slug is taken" do
       @art.title = 'This is the title'
       expect(@art.save).to be_truthy
       @art2 = Article.new(:title => 'This is the title!')
       expect{@art2.save}.to raise_error(/409 Conflict/)
     end
-    
+
     it "should set the slug" do
       @art.title = 'This is the title'
       expect(@art.save).to be_truthy
       expect(@art.slug).to eq('this-is-the-title')
     end
-    
+
     it "should set the id" do
       @art.title = 'This is the title'
       expect(@art.save).to be_truthy
@@ -215,20 +215,20 @@ describe CouchRest::Model::Persistence do
       @old = WithTemplateAndUniqueID.get('very-important') rescue nil
       @old.destroy if @old
     end
-    
+
     it "should require the field" do
       expect{@templated.save}.to raise_error(/unique_id cannot be nil/)
       @templated['slug'] = 'very-important'
       expect(@templated.save).to be_truthy
     end
-    
+
     it "should save with the id" do
       @templated['slug'] = 'very-important'
       expect(@templated.save).to be_truthy
       t = WithTemplateAndUniqueID.get('very-important')
       expect(t).to eq(@templated)
     end
-    
+
     it "should not change the id on update" do
       @templated['slug'] = 'very-important'
       expect(@templated.save).to be_truthy
@@ -237,13 +237,13 @@ describe CouchRest::Model::Persistence do
       t = WithTemplateAndUniqueID.get('very-important')
       expect(t.id).to eq(@templated.id)
     end
-    
+
     it "should raise an error when the id is taken" do
       @templated['slug'] = 'very-important'
       expect(@templated.save).to be_truthy
       expect{WithTemplateAndUniqueID.new('slug' => 'very-important').save}.to raise_error(/409 Conflict/)
     end
-    
+
     it "should set the id" do
       @templated['slug'] = 'very-important'
       expect(@templated.save).to be_truthy
@@ -298,7 +298,7 @@ describe CouchRest::Model::Persistence do
     it "should return nil if `get` is used and the document doesn't exist" do
       foundart = Article.get 'matt aimonetti'
       expect(foundart).to be_nil
-    end                     
+    end
     it "should return nil if a blank id is requested" do
       expect(Article.get("")).to be_nil
     end
@@ -347,11 +347,11 @@ describe CouchRest::Model::Persistence do
   end
 
   describe "callbacks" do
-    
+
     before(:each) do
       @doc = WithCallBacks.new
     end
-    
+
     describe "validation" do
       it "should run before_validation before validating" do
         expect(@doc.run_before_validation).to be_nil
@@ -434,26 +434,28 @@ describe CouchRest::Model::Persistence do
       end
     end
     describe "update" do
-      
+
       before(:each) do
         @doc.save
-      end      
+      end
+
       it "should run the before update filter when updating an existing document" do
         expect(@doc.run_before_update).to be_nil
         @doc.update
         expect(@doc.run_before_update).to be_truthy
       end
+
       it "should run the after update filter when updating an existing document" do
         expect(@doc.run_after_update).to be_nil
         @doc.update
         expect(@doc.run_after_update).to be_truthy
       end
+
       it "should run the before update filter when saving an existing document" do
         expect(@doc.run_before_update).to be_nil
         @doc.save
         expect(@doc.run_before_update).to be_truthy
       end
-      
     end
   end
 

--- a/spec/unit/properties_spec.rb
+++ b/spec/unit/properties_spec.rb
@@ -448,7 +448,7 @@ describe CouchRest::Model::Properties do
         expect(@cat.siblings.first.name).to eql("Feather")
         expect(@cat.siblings.last.casted_by).to eql(@cat)
       end
-    end 
+    end
 
   end
 
@@ -457,21 +457,21 @@ describe CouchRest::Model::Properties do
     before(:each) do
       @obj = WithDefaultValues.new
     end
- 
-    context "with valid params" do        
+
+    context "with valid params" do
       it "should parse a legal date" do
-        valid_date_params = { "exec_date(1i)"=>"2011", 
-                              "exec_date(2i)"=>"10", 
-                              "exec_date(3i)"=>"18"}
+        valid_date_params = { "exec_date(1i)"=>"2011",
+                              "exec_date(2i)"=>"10",
+                              "exec_date(3i)"=>"18" }
         @obj = WithDateAndTime.new valid_date_params
         expect(@obj.exec_date).not_to be_nil
         expect(@obj.exec_date).to be_kind_of(Date)
         expect(@obj.exec_date).to eq(Date.new(2011, 10 ,18))
       end
-    
+
       it "should parse a legal time" do
-        valid_time_params = { "exec_time(1i)"=>"2011", 
-                              "exec_time(2i)"=>"10", 
+        valid_time_params = { "exec_time(1i)"=>"2011",
+                              "exec_time(2i)"=>"10",
                               "exec_time(3i)"=>"18",
                               "exec_time(4i)"=>"15",
                               "exec_time(5i)"=>"15",
@@ -482,18 +482,20 @@ describe CouchRest::Model::Properties do
         expect(@obj.exec_time).to eq(Time.utc(2011, 10 ,18, 15, 15, 15))
       end
     end
-    
+
     context "with invalid params" do
       before(:each) do
-        @invalid_date_params = { "exec_date(1i)"=>"2011", 
-                                 "exec_date(2i)"=>"foo", 
+        @invalid_date_params = { "exec_date(1i)"=>"2011",
+                                 "exec_date(2i)"=>"foo",
                                  "exec_date(3i)"=>"18"}
       end
+
       it "should still create a model if there are invalid attributes" do
         @obj = WithDateAndTime.new @invalid_date_params
         expect(@obj).not_to be_nil
         expect(@obj).to be_kind_of(WithDateAndTime)
       end
+
       it "should not crash because of an empty value" do
         @invalid_date_params["exec_date(2i)"] = ""
         @obj = WithDateAndTime.new @invalid_date_params
@@ -518,10 +520,7 @@ describe CouchRest::Model::Properties do
           @obj = klass.new(:name => 'test (object)')
         }.not_to raise_error
       end
-
     end
-
   end
-
 end
 

--- a/spec/unit/property_protection_spec.rb
+++ b/spec/unit/property_protection_spec.rb
@@ -71,7 +71,7 @@ describe "Model Attributes" do
       expect(user.name).to eq("will")
       expect(user.admin).to eq(false)
     end
-    
+
     it "should provide correct accessible and protected property lists" do
       user = WithAccessible.new(:name => 'will', :admin => true)
       expect(user.accessible_properties.map{|p| p.to_s}).to eql(['name'])

--- a/spec/unit/property_spec.rb
+++ b/spec/unit/property_spec.rb
@@ -13,7 +13,7 @@ describe CouchRest::Model::Property do
     expect(property.to_s).to eql('test')
   end
 
-  it "should provide name as a symbol" do 
+  it "should provide name as a symbol" do
     property = CouchRest::Model::Property.new(:test, :type => String)
     expect(property.name.to_sym).to eql(:test)
     expect(property.to_sym).to eql(:test)

--- a/spec/unit/proxyable_spec.rb
+++ b/spec/unit/proxyable_spec.rb
@@ -16,7 +16,7 @@ describe CouchRest::Model::Proxyable do
 
     before do
       @class = Class.new(CouchRest::Model::Base)
-      @class.class_eval do 
+      @class.class_eval do
         def slug; 'proxy'; end
       end
       @obj = @class.new

--- a/spec/unit/subclass_spec.rb
+++ b/spec/unit/subclass_spec.rb
@@ -33,33 +33,33 @@ end
 class Dog < Animal; end
 
 describe "Subclassing a Model" do
-  
+
   before(:each) do
     @card = BusinessCard.new
   end
-  
+
   it "shouldn't messup the parent's properties" do
     expect(Card.properties).not_to eq(BusinessCard.properties)
   end
-  
+
   it "should share the same db default" do
     expect(@card.database.uri).to eq(Card.database.uri)
   end
-  
+
   it "should have kept the validation details" do
     expect(@card).not_to be_valid
   end
-  
+
   it "should have added the new validation details" do
     validated_fields = @card.class.validators.map{|v| v.attributes}.flatten
     expect(validated_fields).to include(:extension_code)
     expect(validated_fields).to include(:job_title)
   end
-  
+
   it "should not add to the parent's validations" do
     validated_fields = Card.validators.map{|v| v.attributes}.flatten
     expect(validated_fields).not_to include(:extension_code)
-    expect(validated_fields).not_to include(:job_title) 
+    expect(validated_fields).not_to include(:job_title)
   end
 
   it "should inherit default property values" do


### PR DESCRIPTION
This commit will remove hard tabs and trailing whitespace from lines throughout the codebase.

In order to reveal offending lines, I used a version of bundler's [quality_spec](https://github.com/bundler/bundler/blob/master/spec/quality_spec.rb).  The spec breaks with more recent versions of rspec, which is the only reason I haven't included the spec itself with this PR.
