### PR TITLE
raise RuntimeError for not allowed model properties

### DIFF
--- a/lib/couchrest/model/properties.rb
+++ b/lib/couchrest/model/properties.rb
@@ -114,7 +114,7 @@ module CouchRest
             multi_parameter_attributes << [ key, value ]
             false
           elsif self.respond_to?("#{key}=")
-            self.send("#{key}=", value) 
+            self.send("#{key}=", value)
           elsif mass_assign || mass_assign_any_attribute
             couchrest_attribute_will_change!(key) if use_dirty? && self[key] != value
             self[key] = value
@@ -142,7 +142,7 @@ module CouchRest
       def execute_callstack_for_multiparameter_attributes(callstack, hash)
         callstack.each do |name, values_with_empty_parameters|
           if self.respond_to?("#{name}=")
-            casted_attrib = send("#{name}=", values_with_empty_parameters) 
+            casted_attrib = send("#{name}=", values_with_empty_parameters)
             unless casted_attrib.is_a?(Hash)
               hash.reject { |key, value| key.include?(name.to_s)}
             end
@@ -171,6 +171,7 @@ module CouchRest
       module ClassMethods
 
         def property(name, *options, &block)
+          raise "Invalid property definition, '#{name}' already used internally by CouchRest Model" if name.to_s == 'properties'
           raise "Invalid property definition, '#{name}' already used for CouchRest Model type field" if name.to_s == model_type_key.to_s && CouchRest::Model::Base >= self
           opts = { }
           type = options.shift
@@ -188,7 +189,7 @@ module CouchRest
 
         # Automatically set <tt>updated_at</tt> and <tt>created_at</tt> fields
         # on the document whenever saving occurs.
-        # 
+        #
         # These properties are casted as Time objects, so they should always
         # be set to UTC.
         def timestamps!
@@ -255,4 +256,3 @@ module CouchRest
     end
   end
 end
-

--- a/spec/unit/properties_spec.rb
+++ b/spec/unit/properties_spec.rb
@@ -3,25 +3,39 @@ require "spec_helper"
 
 describe CouchRest::Model::Properties do
 
-  before(:each) do
-    @obj = WithDefaultValues.new
+  describe '.property' do
+    before do
+      stub_const 'Invalid', Class.new(CouchRest::Model::Base)
+    end
+
+    it "raises an exception when the model has a property named 'properties'" do
+      expect do
+        Invalid.class_eval{ property :properties }
+      end.to raise_error(RuntimeError, /'properties' already used internally by CouchRest Model/)
+    end
+
+    it "raises an exception when the model has a property named 'type'" do
+      expect do
+        Invalid.class_eval{ property :type }
+      end.to raise_error(RuntimeError, /type' already used for CouchRest Model type field/)
+    end
   end
- 
+
   describe "multipart attributes" do
-    context "with valid params" do        
+    context "with valid params" do
       it "should parse a legal date" do
-        valid_date_params = { "exec_date(1i)"=>"2011", 
-                              "exec_date(2i)"=>"10", 
+        valid_date_params = { "exec_date(1i)"=>"2011",
+                              "exec_date(2i)"=>"10",
                               "exec_date(3i)"=>"18"}
         @obj = WithDateAndTime.new valid_date_params
         @obj.exec_date.should_not be_nil
         @obj.exec_date.should be_kind_of(Date)
         @obj.exec_date.should == Date.new(2011, 10 ,18)
       end
-    
+
       it "should parse a legal time" do
-        valid_time_params = { "exec_time(1i)"=>"2011", 
-                              "exec_time(2i)"=>"10", 
+        valid_time_params = { "exec_time(1i)"=>"2011",
+                              "exec_time(2i)"=>"10",
                               "exec_time(3i)"=>"18",
                               "exec_time(4i)"=>"15",
                               "exec_time(5i)"=>"15",
@@ -32,11 +46,11 @@ describe CouchRest::Model::Properties do
         @obj.exec_time.should == Time.utc(2011, 10 ,18, 15, 15, 15)
       end
     end
-    
+
     context "with invalid params" do
       before(:each) do
-        @invalid_date_params = { "exec_date(1i)"=>"2011", 
-                                 "exec_date(2i)"=>"foo", 
+        @invalid_date_params = { "exec_date(1i)"=>"2011",
+                                 "exec_date(2i)"=>"foo",
                                  "exec_date(3i)"=>"18"}
       end
       it "should still create a model if there are invalid attributes" do
@@ -74,4 +88,3 @@ describe CouchRest::Model::Properties do
   end
 
 end
-


### PR DESCRIPTION
As stated by issue #198, a model ```property``` named ```properties``` is not correctly handled by couchrest_model.

In This [line](https://github.com/couchrest/couchrest_model/blob/master/lib/couchrest/model/properties.rb#L27), ```properties``` from model is clashing with ```properties``` from the object itself. The fix is not straightforward and for now I'm proposing an exception guard.

This PR raises an RuntimeError in an attempt of use ```properties``` as a model ```property```.