### PR TITLE
Update gemspec to support Rails 5

### DIFF
--- a/couchrest_model.gemspec
+++ b/couchrest_model.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency("couchrest",   "2.0.0.rc3")
-  s.add_dependency("activemodel", "~> 4.0")
+  s.add_dependency("activemodel", ">= 4.0", "< 5.1")
   s.add_dependency("tzinfo",      ">= 0.3.22")
   s.add_development_dependency("rspec", "~> 2.14.1")
   s.add_development_dependency("rack-test", ">= 0.5.7")
@@ -31,5 +31,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency("test-unit")
   s.add_development_dependency("minitest", "> 4.1") #, "< 5.0") # For Kaminari and activesupport, pending removal
   s.add_development_dependency("kaminari", ">= 0.14.1", "< 0.16.0")
-  s.add_development_dependency("mime-types", "< 3.0") # Mime-types > 3.0 don't bundle properly on JRuby
+  s.add_development_dependency("mime-types", "<= 3.0") # Mime-types > 3.0 don't bundle properly on JRuby
 end


### PR DESCRIPTION
This change is needed to support Rails 5 dependencies. It seems that everything is working flawlessly on Rails 5 RC1.
