### PR TITLE
Support proxying to multiple databases

### DIFF
--- a/lib/couchrest/model/proxyable.rb
+++ b/lib/couchrest/model/proxyable.rb
@@ -4,9 +4,10 @@ module CouchRest
     module Proxyable
       extend ActiveSupport::Concern
 
-      def proxy_database(suffix = nil)
+      def proxy_database(assoc_name, suffix = nil)
         raise StandardError, "Please set the #proxy_database_method" if self.class.proxy_database_method.nil?
-        @proxy_database ||= self.class.prepare_database([self.send(self.class.proxy_database_method), suffix].compact.reject(&:blank?).join(self.class.connection[:join]))
+        @proxy_databases ||= {}
+        @proxy_databases[assoc_name.to_sym] ||= self.class.prepare_database([self.send(self.class.proxy_database_method), suffix].compact.reject(&:blank?).join(self.class.connection[:join]))
       end
 
       module ClassMethods
@@ -20,7 +21,7 @@ module CouchRest
           options[:class_name] ||= assoc_name.to_s.singularize.camelize
           proxy_method_names   << assoc_name.to_sym    unless proxy_method_names.include?(assoc_name.to_sym)
           proxied_model_names  << options[:class_name] unless proxied_model_names.include?(options[:class_name])
-          db_method_call = db_suffix ? "#{db_method}(\"#{db_suffix}\")" : db_method
+          db_method_call = db_suffix ? "#{db_method}(:#{assoc_name.to_s}, \"#{db_suffix}\")" : "#{db_method}(:#{assoc_name.to_s})"
           class_eval <<-EOS, __FILE__, __LINE__ + 1
             def #{assoc_name}
               @#{assoc_name} ||= CouchRest::Model::Proxyable::ModelProxy.new(::#{options[:class_name]}, self, self.class.to_s.underscore, #{db_method_call})

--- a/lib/couchrest/model/proxyable.rb
+++ b/lib/couchrest/model/proxyable.rb
@@ -6,8 +6,10 @@ module CouchRest
 
       def proxy_database(assoc_name)
         raise StandardError, "Please set the #proxy_database_method" if self.class.proxy_database_method.nil?
+        db_name = self.send(self.class.proxy_database_method)
+        db_suffix = self.class.proxy_database_suffixes[assoc_name.to_sym]
         @proxy_databases ||= {}
-        @proxy_databases[assoc_name.to_sym] ||= self.class.prepare_database([self.send(self.class.proxy_database_method), self.class.proxy_database_suffixes[assoc_name.to_sym]].compact.reject(&:blank?).join(self.class.connection[:join]))
+        @proxy_databases[assoc_name.to_sym] ||= self.class.prepare_database([db_name, db_suffix].compact.reject(&:blank?).join(self.class.connection[:join]))
       end
 
       module ClassMethods

--- a/spec/unit/proxyable_spec.rb
+++ b/spec/unit/proxyable_spec.rb
@@ -83,6 +83,12 @@ describe CouchRest::Model::Proxyable do
         @class.proxy_method_names.should eql([:cats])
       end
 
+      it "should accept a class_name override" do
+        @class.proxy_for(:felines, class_name: "Cat")
+        @class.proxy_method_names.should eql([:felines])
+        @class.proxied_model_names.should eql(['Cat'])
+      end
+
       it "should create a new method" do
         DummyProxyable.stub(:method_defined?).and_return(true)
         DummyProxyable.proxy_for(:cats)


### PR DESCRIPTION
The current implementation only allows one proxy database per parent class.

```ruby
class Company < CouchRest::Model::Base
  property :slug
  proxy_database_method :slug

  proxy_for :invoices
  proxy_for :estimates
end

class Invoice < CouchRest::Model::Base
  proxied_by :company
end

class Estimate < CouchRest::Model::Base
  proxied_by :company
end
```

In this example, both `invoices` and `estimates` would be saved in the same database (`"#{a_company.slug}"`). This PR adds two options to allow these classes to be saved in derived databases.

```ruby
class Company < CouchRest::Model::Base
  property :slug
  proxy_database_method :slug

  proxy_for :invoices, use_suffix: true
  proxy_for :estimates, database_suffix: "documents"
end

class Invoice < CouchRest::Model::Base
  proxied_by :company
end

class Estimate < CouchRest::Model::Base
  proxied_by :company
end
```

Here, invoices will be saved in `"#{a_company.slug}_invoices"` and estimates will be saved in `"#{a_company.slug}_documents"`.