### PR TITLE
Add view option to specify a custom emit value for views

### DIFF
--- a/lib/couchrest/model/designs/view.rb
+++ b/lib/couchrest/model/designs/view.rb
@@ -493,6 +493,7 @@ module CouchRest
 
               # convert emit symbols to properties
               opts[:emit] = "doc['#{opts[:emit]}']" if opts[:emit].try { is_a?(Symbol) }
+              opts[:emit] = "[" + opts[:emit].map { |i| i.is_a?(Symbol) ? "doc['#{i}']" : i }.join(', ') + "]" if opts[:emit].try { is_a?(Array) }
 
               opts[:allow_blank] = opts[:allow_blank].nil? ? true : opts[:allow_blank]
               opts[:guards] ||= []

--- a/lib/couchrest/model/designs/view.rb
+++ b/lib/couchrest/model/designs/view.rb
@@ -491,18 +491,22 @@ module CouchRest
               end
               raise "View cannot be created without recognised name, :map or :by options" if opts[:by].nil?
 
+              # convert emit symbols to properties
+              opts[:emit] = "doc['#{opts[:emit]}']" if opts[:emit].try { is_a?(Symbol) }
+
               opts[:allow_blank] = opts[:allow_blank].nil? ? true : opts[:allow_blank]
               opts[:guards] ||= []
               opts[:guards].push "(doc['#{model.model_type_key}'] == '#{model.model_type_value}')"
 
               keys = opts[:by].map{|o| "doc['#{o}']"}
-              emit = keys.length == 1 ? keys.first : "[#{keys.join(', ')}]"
+              emit_keys = keys.length == 1 ? keys.first : "[#{keys.join(', ')}]"
+              emit_value = opts[:emit] || 1;
               opts[:guards] += keys.map{|k| "(#{k} != null)"} unless opts[:allow_nil]
               opts[:guards] += keys.map{|k| "(#{k} != '')"} unless opts[:allow_blank]
               opts[:map] = <<-EOF
                 function(doc) {
                   if (#{opts[:guards].join(' && ')}) {
-                    emit(#{emit}, 1);
+                    emit(#{emit_keys}, #{emit_value});
                   }
                 }
               EOF

--- a/spec/unit/designs/view_spec.rb
+++ b/spec/unit/designs/view_spec.rb
@@ -169,6 +169,12 @@ describe "Design View" do
           str = @design_doc['views']['by_title']['map']
           str.should include("emit(doc['title'], 3);")
         end
+
+        it "should support emitting an array" do
+          @klass.define(@design_doc, 'by_title', :emit => [1, :name])
+          str = @design_doc['views']['by_title']['map']
+          str.should include("emit(doc['title'], [1, doc['name']]);")
+        end
       end
 
       describe ".create_model_methods" do

--- a/spec/unit/designs/view_spec.rb
+++ b/spec/unit/designs/view_spec.rb
@@ -157,6 +157,18 @@ describe "Design View" do
           @klass.define(@design_doc, 'by_title', :reduce => :stats)
           @design_doc['views']['by_title']['reduce'].should eql('_stats')
         end
+
+        it "should allow the emit value to be overridden" do
+          @klass.define(@design_doc, 'by_title', :emit => :name)
+          str = @design_doc['views']['by_title']['map']
+          str.should include("emit(doc['title'], doc['name']);")
+        end
+
+        it "should forward a non-symbol emit value straight into the view" do
+          @klass.define(@design_doc, 'by_title', :emit => 3)
+          str = @design_doc['views']['by_title']['map']
+          str.should include("emit(doc['title'], 3);")
+        end
       end
 
       describe ".create_model_methods" do


### PR DESCRIPTION
The current implementation of generated views is to always `emit(keys, 1)`, which allows a simple count to be gathered using the default `_sum` reduce function. This PR adds the option for the emit value to be specified without having to write the entire map function in javascript.

The example below would create a view that can be queried for total amount taken per client per day.

```ruby
class Invoice < CouchRest::Model::Base
  property :client_id
  property :date
  property :total_amount

  design do
    view :by_client_id_and_date, emit: :total_amount
  end
end
```

Generated javascript:

```js
function(doc) {
  if ((doc['type'] == 'Invoice') && (doc['client_id'] != null) && (doc['date'] != null)) {
    emit([doc['client_id'], doc['date']], doc['total_amount']);
  }
}

```