### PR TITLE
Implement proxy for factory methods

### DIFF
--- a/lib/couchrest/model/proxyable.rb
+++ b/lib/couchrest/model/proxyable.rb
@@ -156,6 +156,12 @@ module CouchRest
           end
         end
 
+        private
+
+        def method_missing(m, *args, &block)
+          model.send(m, self, *args, &block)
+        end
+        
       end
     end
   end

--- a/lib/couchrest/model/proxyable.rb
+++ b/lib/couchrest/model/proxyable.rb
@@ -159,7 +159,7 @@ module CouchRest
         private
 
         def method_missing(m, *args, &block)
-          model.send(m, self, *args, &block)
+          model.respond_to?(m) ? model.send(m, self, *args, &block) : super
         end
         
       end

--- a/spec/unit/proxyable_spec.rb
+++ b/spec/unit/proxyable_spec.rb
@@ -227,7 +227,6 @@ describe CouchRest::Model::Proxyable do
         @obj.should_receive(:by_name).and_return(view)
         lambda { @obj.find_by_name!('name') }.should raise_error(CouchRest::Model::DocumentNotFound)
       end
-
     end
 
     describe "instance" do
@@ -268,10 +267,17 @@ describe CouchRest::Model::Proxyable do
         @obj.should_receive(:proxy_update)
         @obj.get(32)
       end
+
       it "should proxy #find" do
         @model.should_receive(:get).with(32, 'database')
         @obj.should_receive(:proxy_update)
         @obj.find(32)
+      end
+
+      it "should proxy factory methods" do
+        # *args = *["arg_1", "arg_2"]
+        @model.should_receive(:factory_method).with(@obj, "arg_1", "arg_2")
+        @obj.factory_method("arg_1", "arg_2")
       end
 
 

--- a/spec/unit/proxyable_spec.rb
+++ b/spec/unit/proxyable_spec.rb
@@ -275,9 +275,12 @@ describe CouchRest::Model::Proxyable do
       end
 
       it "should proxy factory methods" do
-        # *args = *["arg_1", "arg_2"]
         @model.should_receive(:factory_method).with(@obj, "arg_1", "arg_2")
         @obj.factory_method("arg_1", "arg_2")
+      end
+
+      it "shouldn't forward undefined model methods" do
+        lambda { @obj.undefined_factory_method("arg_1", "arg_2") }.should raise_error(NoMethodError, /CouchRest::Model::Proxy/)
       end
 
 


### PR DESCRIPTION
Allow the proxy to forward factory methods via `method_missing`.

```ruby
class Invoice < CouchRest::Model::Base
  proxied_by :company
  property :date, Time

  def self.from_timestamp(proxy, timestamp)
    instance = proxy.new
    instance.date = Time.at(timestamp)
    instance.save
  end
end

# allows the proxy to use the from_timestamp method
company = Company.get("my_company_id")
new_invoice = company.invoices.from_timestamp(Time.now.to_id)
```