### PR TITLE
Making running the tests a bit easier

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM ruby:2.3
+
+ENV WORK_DIR /usr/lib/couchrest_model
+
+RUN mkdir -p $WORK_DIR
+
+COPY . $WORK_DIR
+RUN cd $WORK_DIR && bundle install
+
+WORKDIR $WORK_DIR

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,9 @@ FROM ruby:2.3
 ENV WORK_DIR /usr/lib/couchrest_model
 
 RUN mkdir -p $WORK_DIR
+WORKDIR $WORK_DIR
 
 COPY . $WORK_DIR
-RUN cd $WORK_DIR && bundle install
 
-WORKDIR $WORK_DIR
+RUN bundle install --jobs=3 --retry=3
+

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,7 @@
 source "https://rubygems.org"
 gemspec
 
+gem "guard-rspec", "~> 4.7.0", group: :test
+
 # Enable for testing against local couchrest
 # gem "couchrest", path: "/Users/sam/workspace/couchrest"

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,31 @@
+# A sample Guardfile
+# More info at https://github.com/guard/guard#readme
+
+## Uncomment and set this to only include directories you want to watch
+# directories %w(app lib config test spec features) \
+#  .select{|d| Dir.exists?(d) ? d : UI.warning("Directory #{d} does not exist")}
+
+## Note: if you are using the `directories` clause above and you are not
+## watching the project directory ('.'), then you will want to move
+## the Guardfile to a watched dir and symlink it back, e.g.
+#
+#  $ mkdir config
+#  $ mv Guardfile config/
+#  $ ln -s config/Guardfile .
+#
+# and, you'll have to watch "config/Guardfile" instead of "Guardfile"
+
+# Note: The cmd option is now required due to the increasing number of ways
+#       rspec may be run, below are examples of the most common uses.
+#  * bundler: 'bundle exec rspec'
+#  * bundler binstubs: 'bin/rspec'
+#  * spring: 'bin/rsspec' (This will use spring if running and you have
+#                          installed the spring binstubs per the docs)
+#  * zeus: 'zeus rspec' (requires the server to be started separetly)
+#  * 'just' rspec: 'rspec'
+guard :rspec, cmd: 'rspec' do
+  watch(%r{^spec/.+_spec\.rb$})
+  watch(%r{^lib/couchrest/model/(.+)\.rb$})     { |m| "spec/unit/#{m[1]}_spec.rb" }
+  watch('spec/spec_helper.rb')  { "spec" }
+end
+

--- a/couchrest_model.gemspec
+++ b/couchrest_model.gemspec
@@ -33,4 +33,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency("minitest", "> 4.1") #, "< 5.0") # For Kaminari and activesupport, pending removal
   s.add_development_dependency("kaminari", ">= 0.14.1", "< 0.16.0")
   s.add_development_dependency("mime-types", "< 3.0") # Mime-types > 3.0 don't bundle properly on JRuby
+  s.add_development_dependency("guard-rspec", "~> 4.7.0")
 end

--- a/couchrest_model.gemspec
+++ b/couchrest_model.gemspec
@@ -33,5 +33,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency("minitest", "> 4.1") #, "< 5.0") # For Kaminari and activesupport, pending removal
   s.add_development_dependency("kaminari", ">= 0.14.1", "< 0.16.0")
   s.add_development_dependency("mime-types", "< 3.0") # Mime-types > 3.0 don't bundle properly on JRuby
-  s.add_development_dependency("guard-rspec", "~> 4.7.0")
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: "2"
+services:
+  test:
+    build:
+      context: .
+    entrypoint: ["bundle", "exec"]
+    command: ["rspec"]
+    environment:
+      RAILS_ENV: test
+      COUCH_HOST: "http://couch:5984/"
+    depends_on:
+      - couch
+    volumes:
+      - ./:/usr/lib/couchrest_model
+    networks:
+      - couchrest_model
+  couch:
+    image: couchdb:1.6
+    ports:
+      - "5984"
+    networks:
+      - couchrest_model
+      - default
+networks:
+  couchrest_model:
+    driver: bridge

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,7 +15,7 @@ unless defined?(FIXTURE_PATH)
   FIXTURE_PATH = File.join(File.dirname(__FILE__), '/fixtures')
   SCRATCH_PATH = File.join(File.dirname(__FILE__), '/tmp')
 
-  COUCHHOST = "http://127.0.0.1:5984"
+  COUCHHOST = ENV["COUCH_HOST"] || "http://127.0.0.1:5984"
   TESTDB    = 'couchrest-model-test'
   TEST_SERVER    = CouchRest.new COUCHHOST
   # TEST_SERVER.default_database = TESTDB
@@ -23,6 +23,21 @@ unless defined?(FIXTURE_PATH)
 end
 
 RSpec.configure do |config|
+  config.before(:suite) do
+    couch_uri = URI.parse(ENV['COUCH_HOST'] || "http://127.0.0.1:5984")
+    CouchRest::Model::Base.configure do |config|
+      config.connection  = {
+        :protocol => couch_uri.scheme,
+        :host     => couch_uri.host,
+        :port     => couch_uri.port,
+        :username => couch_uri.user,
+        :password => couch_uri.password,
+        :prefix   => "couchrest",
+        :join     => "_"
+      }
+    end
+  end
+
   config.before(:all) { reset_test_db! }
 
   config.after(:all) do

--- a/spec/unit/connection_spec.rb
+++ b/spec/unit/connection_spec.rb
@@ -90,7 +90,7 @@ describe CouchRest::Model::Connection do
         expect(@class.server).to be_a(CouchRest::Server)
       end
       it "should provide a server with default config" do
-        expect(@class.server.uri.to_s).to eql("http://localhost:5984")
+        expect(@class.server.uri.to_s).to eql(CouchRest::Model::Base.server.uri.to_s)
       end
       it "should allow the configuration to be overwritten" do
         @class.connection = {


### PR DESCRIPTION
It's fine for this to be ignored, but I like to dockerize everything I work on. This change just makes running the tests really easy if you have docker installed on your machine.

``` bash
docker-compose up test
```

I've also integrated guard to run the tests automatically during development. This will only work if the container can detect file changes (which requires docker to not be running insider a Virtual Box VM).

``` bash
docker-compose run test guard
```
