### PR TITLE
Add some guards to prevent view errors when using custom emit values

### DIFF
--- a/lib/couchrest/model/designs/view.rb
+++ b/lib/couchrest/model/designs/view.rb
@@ -492,8 +492,16 @@ module CouchRest
               raise "View cannot be created without recognised name, :map or :by options" if opts[:by].nil?
 
               # convert emit symbols to properties
-              opts[:emit] = "doc['#{opts[:emit]}']" if opts[:emit].is_a?(Symbol)
-              opts[:emit] = "[" + opts[:emit].map { |i| i.is_a?(Symbol) ? "doc['#{i}']" : i }.join(', ') + "]" if opts[:emit].is_a?(Array)
+              emits, emit_guards = if opts[:emit].is_a? Symbol
+                [["doc['#{opts[:emit]}']"], ["doc['#{opts[:emit]}']"]]
+              elsif opts[:emit].is_a? Array
+                [
+                  opts[:emit].map { |i| i.is_a?(Symbol) ? "doc['#{i}']" : i },
+                  opts[:emit].map { |i| i.is_a?(Symbol) ? "doc['#{i}']" : nil}.flatten
+                ]
+              else
+                [[opts[:emit] || 1], nil]
+              end
 
               opts[:allow_blank] = opts[:allow_blank].nil? ? true : opts[:allow_blank]
               opts[:guards] ||= []
@@ -501,9 +509,11 @@ module CouchRest
 
               keys = opts[:by].map{|o| "doc['#{o}']"}
               emit_keys = keys.length == 1 ? keys.first : "[#{keys.join(', ')}]"
-              emit_value = opts[:emit] || 1;
+              emit_value = emits.length == 1 ? emits.first : "[#{emits.join(', ')}]"
               opts[:guards] += keys.map{|k| "(#{k} != null)"} unless opts[:allow_nil]
               opts[:guards] += keys.map{|k| "(#{k} != '')"} unless opts[:allow_blank]
+              opts[:guards] += emit_guards.map{|k| "(#{k} != null)"} unless emit_guards.nil? || opts[:allow_nil]
+              opts[:guards] += emit_guards.map{|k| "(#{k} != '')"} unless emit_guards.nil? || opts[:allow_blank]
               opts[:map] = <<-EOF
                 function(doc) {
                   if (#{opts[:guards].join(' && ')}) {
@@ -511,7 +521,7 @@ module CouchRest
                   }
                 }
               EOF
-              if opts[:reduce].nil?
+              if opts[:reduce].nil? && emit_guards.nil?
                 # Use built-in sum function by default
                 opts[:reduce] = "_sum"
               end

--- a/lib/couchrest/model/designs/view.rb
+++ b/lib/couchrest/model/designs/view.rb
@@ -497,7 +497,7 @@ module CouchRest
               elsif opts[:emit].is_a? Array
                 [
                   opts[:emit].map { |i| i.is_a?(Symbol) ? "doc['#{i}']" : i },
-                  opts[:emit].map { |i| i.is_a?(Symbol) ? "doc['#{i}']" : nil}.flatten
+                  opts[:emit].map { |i| i.is_a?(Symbol) ? "doc['#{i}']" : nil}.compact
                 ]
               else
                 [[opts[:emit] || 1], nil]

--- a/spec/unit/designs/view_spec.rb
+++ b/spec/unit/designs/view_spec.rb
@@ -158,7 +158,7 @@ describe "Design View" do
           expect(@design_doc['views']['by_title']['reduce']).to eql('_stats')
         end
 
-        it "should allow the emit value to be overridden" do
+        it "should allow the emit value to be overidden" do
           @klass.define(@design_doc, 'by_title', :emit => :name)
           str = @design_doc['views']['by_title']['map']
           expect(str).to include("emit(doc['title'], doc['name']);")
@@ -174,6 +174,25 @@ describe "Design View" do
           @klass.define(@design_doc, 'by_title', :emit => [1, :name])
           str = @design_doc['views']['by_title']['map']
           expect(str).to include("emit(doc['title'], [1, doc['name']]);")
+        end
+
+        it "should guard against nulls when emitting properties" do
+          @klass.define(@design_doc, 'by_title', :emit => :name)
+          str = @design_doc['views']['by_title']['map']
+          expect(str).to include("doc['name'] != null")
+        end
+
+        it "should guard against nulls when emitting multiple properties" do
+          @klass.define(@design_doc, 'by_title', :emit => [:name, :another_property])
+          str = @design_doc['views']['by_title']['map']
+          expect(str).to include("doc['name'] != null")
+          expect(str).to include("doc['another_property'] != null")
+        end
+
+        it "should not provide a default reduce function the emit value is overidden" do
+          @klass.define(@design_doc, 'by_title', :emit => :name)
+          str = @design_doc['views']['by_title']['reduce']
+          expect(str).to be_nil
         end
       end
 

--- a/spec/unit/designs/view_spec.rb
+++ b/spec/unit/designs/view_spec.rb
@@ -189,6 +189,12 @@ describe "Design View" do
           expect(str).to include("doc['another_property'] != null")
         end
 
+        it "should not guard against nulls for non-symbol emits" do
+          @klass.define(@design_doc, 'by_title', :emit => [:name, 3])
+          str = @design_doc['views']['by_title']['map']
+          expect(str).not_to include("( != null)")
+        end
+
         it "should not provide a default reduce function the emit value is overridden" do
           @klass.define(@design_doc, 'by_title', :emit => :name)
           str = @design_doc['views']['by_title']['reduce']

--- a/spec/unit/designs/view_spec.rb
+++ b/spec/unit/designs/view_spec.rb
@@ -158,7 +158,7 @@ describe "Design View" do
           expect(@design_doc['views']['by_title']['reduce']).to eql('_stats')
         end
 
-        it "should allow the emit value to be overidden" do
+        it "should allow the emit value to be overridden" do
           @klass.define(@design_doc, 'by_title', :emit => :name)
           str = @design_doc['views']['by_title']['map']
           expect(str).to include("emit(doc['title'], doc['name']);")
@@ -189,7 +189,7 @@ describe "Design View" do
           expect(str).to include("doc['another_property'] != null")
         end
 
-        it "should not provide a default reduce function the emit value is overidden" do
+        it "should not provide a default reduce function the emit value is overridden" do
           @klass.define(@design_doc, 'by_title', :emit => :name)
           str = @design_doc['views']['by_title']['reduce']
           expect(str).to be_nil


### PR DESCRIPTION
This PR adds some defence against couch errors with the changes I made in #209. It guards against null values in the custom emit options by default, and also removes the default `_sum` reduce function if an `emit` option has been specified (to guard against the `emit` value being non-numeric, leading to the `_sum` function failing). To use the same example as I did in the original pull request:

``` ruby
class Invoice < CouchRest::Model::Base
  property :client_id
  property :date
  property :total_amount

  design do
    view :by_client_id_and_date, emit: :total_amount
  end
end
```

Generated map function:

``` javascript
function(doc) {
  if ((doc['type'] == 'Invoice') && (doc['client_id'] != null) && (doc['date'] != null) && (doc['total_amount'] != null)) {
    emit([doc['client_id'], doc['date']], doc['total_amount']);
  }
}
```

This example would also no longer have a reduce function.
