### PR TITLE
Migration improvements

### DIFF
--- a/lib/couchrest/model/designs/migrations.rb
+++ b/lib/couchrest/model/designs/migrations.rb
@@ -46,6 +46,9 @@ module CouchRest
           id      = self['_id']
 
           if !doc
+            # make sure the checksum has been calculated
+            checksum! if !self['couchrest-hash']
+            
             # no need to migrate, just save it
             new_doc = to_hash.dup
             db.save_doc(new_doc)

--- a/lib/couchrest/model/utils/migrate.rb
+++ b/lib/couchrest/model/utils/migrate.rb
@@ -95,6 +95,7 @@ module CouchRest
             methods = model_class.proxy_method_names
             methods.each do |method|
               puts "Finding proxied models for #{model_class}##{method}"
+              model_class.design_doc.auto_update = false
               model.all.each do |obj|
                 proxy = obj.send(method)
                 callbacks += migrate_each_model([proxy.model], proxy.database)

--- a/spec/unit/designs/migrations_spec.rb
+++ b/spec/unit/designs/migrations_spec.rb
@@ -42,6 +42,7 @@ describe CouchRest::Model::Designs::Migrations do
           end
           doc = @db.get(@doc['_id'])
           expect(doc['views']['all']).to eql(@doc['views']['all'])
+          expect(doc['couchrest-hash']).not_to be_nil
           expect(callback).to be_nil
         end
 

--- a/spec/unit/utils/migrate_spec.rb
+++ b/spec/unit/utils/migrate_spec.rb
@@ -1,5 +1,32 @@
-
 require 'spec_helper'
+
+class MigrateModel < CouchRest::Model::Base
+  use_database :migrations
+  proxy_database_method :id
+  proxy_for :migrate_proxy_models
+  property :name
+  design { view :by_name }
+end
+
+class MigrateProxyModel < CouchRest::Model::Base
+  proxied_by :migrate_model
+  proxy_database_method :id
+  proxy_for :migrate_proxy_nested_models
+  property :name
+  design { view :by_name }
+end
+
+class MigrateProxyNestedModel < CouchRest::Model::Base
+  proxied_by :migrate_proxy_model
+  property :name
+  design { view :by_name }
+end
+
+RSpec::Matchers.define :database_matching do |database|
+  match do |actual|
+    actual.server == database.server && actual.name == database.name
+  end
+end
 
 describe CouchRest::Model::Utils::Migrate do
 
@@ -11,6 +38,7 @@ describe CouchRest::Model::Utils::Migrate do
     it "should not do anything if Rails is not available" do
       @module.load_all_models
     end
+
     it "should detect if Rails is available and require models" do
       Rails = double()
       allow(Rails).to receive(:root).and_return("")
@@ -22,4 +50,55 @@ describe CouchRest::Model::Utils::Migrate do
     end
   end
 
+  describe "migrations" do
+    let!(:stdout) { $stdout }
+    before :each do
+      allow(CouchRest::Model::Base).to receive(:subclasses).and_return([MigrateModel, MigrateProxyModel, MigrateProxyNestedModel])
+      $stdout = StringIO.new
+    end
+
+    after :each do
+      $stdout = stdout
+    end
+
+    describe "#all_models" do
+      it "should migrate root subclasses of CouchRest::Model::Base" do
+        expect(MigrateModel.design_docs.first).to receive(:migrate)
+        @module.all_models
+      end
+
+      it "shouldn't migrate proxied subclasses with of CouchRest::Model::Base" do
+        expect(MigrateProxyModel.design_docs.first).not_to receive(:migrate)
+        expect(MigrateProxyNestedModel.design_docs.first).not_to receive(:migrate)
+        @module.all_models
+      end
+    end
+
+    describe "#all_models_and_proxies" do
+      before :each do
+        # clear data from previous test runs
+        MigrateModel.all.each do |mm|
+          mm.migrate_proxy_models.all.each do |mpm|
+            mpm.migrate_proxy_nested_models.database.delete! rescue nil
+          end rescue nil
+          mm.migrate_proxy_models.database.delete!
+          mm.destroy
+        end
+        MigrateModel.database.recreate!
+      end
+
+      it "should migrate first level proxied subclasses of CouchRest::Model::Base" do
+        mm = MigrateModel.new(name: "Migration").save
+        expect(MigrateProxyModel.design_docs.first).to receive(:migrate).with(database_matching(mm.migrate_proxy_models.database))
+        @module.all_models_and_proxies
+      end
+
+      it "should migrate the second level proxied subclasses of CouchRest::Model::Base" do
+        mm = MigrateModel.new(name: "Migration").save
+        mpm = mm.migrate_proxy_models.new(name: "Migration Proxy").save
+        expect(MigrateProxyNestedModel.design_docs.first).to receive(:migrate).with(database_matching(mpm.migrate_proxy_nested_models.database))
+        @module.all_models_and_proxies
+      end
+    end
+  end
 end

--- a/spec/unit/utils/migrate_spec.rb
+++ b/spec/unit/utils/migrate_spec.rb
@@ -5,6 +5,7 @@ class MigrateModel < CouchRest::Model::Base
   proxy_database_method :id
   proxy_for :migrate_proxy_models
   property :name
+  property :value
   design { view :by_name }
 end
 
@@ -13,12 +14,14 @@ class MigrateProxyModel < CouchRest::Model::Base
   proxy_database_method :id
   proxy_for :migrate_proxy_nested_models
   property :name
+  property :value
   design { view :by_name }
 end
 
 class MigrateProxyNestedModel < CouchRest::Model::Base
   proxied_by :migrate_proxy_model
   property :name
+  property :value
   design { view :by_name }
 end
 
@@ -72,6 +75,30 @@ describe CouchRest::Model::Utils::Migrate do
         expect(MigrateProxyNestedModel.design_docs.first).not_to receive(:migrate)
         @module.all_models
       end
+
+      context "migration design docs" do
+        before :each do
+          @module.all_models
+          @design_doc = MigrateModel.design_doc
+        end
+
+        it "shouldn't modify the original design doc if activate is false" do
+          @design_doc.create_view(:by_name_and_id)
+          @module.all_models(activate: false)
+
+          fetched_ddoc = MigrateModel.get(@design_doc.id)
+          expect(fetched_ddoc['views']).not_to have_key('by_name_and_id')
+        end
+
+        it "should remove a leftover migration doc" do
+          @design_doc.create_view(:by_name_and_value)
+          @module.all_models(activate: false)
+
+          expect(MigrateModel.get("#{@design_doc.id}_migration")).not_to be_nil
+          @module.all_models
+          expect(MigrateModel.get("#{@design_doc.id}_migration")).to be_nil
+        end
+      end
     end
 
     describe "#all_models_and_proxies" do
@@ -82,14 +109,14 @@ describe CouchRest::Model::Utils::Migrate do
             mpm.migrate_proxy_nested_models.database.delete! rescue nil
           end rescue nil
           mm.migrate_proxy_models.database.delete!
-          mm.destroy
+          mm.destroy rescue nil
         end
         MigrateModel.database.recreate!
       end
 
       it "should migrate first level proxied subclasses of CouchRest::Model::Base" do
         mm = MigrateModel.new(name: "Migration").save
-        expect(MigrateProxyModel.design_docs.first).to receive(:migrate).with(database_matching(mm.migrate_proxy_models.database))
+        expect(MigrateProxyModel.design_docs.first).to receive(:migrate).with(database_matching(mm.migrate_proxy_models.database)).and_call_original
         @module.all_models_and_proxies
       end
 
@@ -98,6 +125,34 @@ describe CouchRest::Model::Utils::Migrate do
         mpm = mm.migrate_proxy_models.new(name: "Migration Proxy").save
         expect(MigrateProxyNestedModel.design_docs.first).to receive(:migrate).with(database_matching(mpm.migrate_proxy_nested_models.database))
         @module.all_models_and_proxies
+      end
+
+      context "migration design docs" do
+        before :each do
+          @mm_instance = MigrateModel.new(name: "Migration").save
+          mpm = @mm_instance.migrate_proxy_models.new(name: "Migration Proxy")
+
+          @module.all_models_and_proxies
+
+          @design_doc = MigrateProxyModel.design_doc
+        end
+
+        it "shouldn't modify the original design doc if activate is false" do
+          @design_doc.create_view(:by_name_and_id)
+          @module.all_models_and_proxies(activate: false)
+
+          fetched_ddoc = @mm_instance.migrate_proxy_models.get(@design_doc.id)
+          expect(fetched_ddoc['views']).not_to have_key('by_name_and_id')
+        end
+
+        it "should remove a leftover migration doc" do
+          @design_doc.create_view(:by_name_and_value)
+          @module.all_models_and_proxies(activate: false)
+
+          expect(@mm_instance.migrate_proxy_models.get("#{@design_doc.id}_migration")).not_to be_nil
+          @module.all_models_and_proxies
+          expect(@mm_instance.migrate_proxy_models.get("#{@design_doc.id}_migration")).to be_nil
+        end
       end
     end
   end


### PR DESCRIPTION
I've made a couple of changes here:
#### Make sure that `couchrest-hash` is set on _created_ design docs during migrations

The current behaviour is that running `migrate` on a new design doc twice would result in `:created` and then `:migrated`, performing the view indexing both times. With this change the results of that example are now `:created` and then `:no_change`.
#### Add support for nested proxies in `CouchRest::Model::Utils`

``` ruby
class Company < CouchRest::Model::Base
  proxy_database_method :id
  proxy_for :clients
  property :name
  design { view :by_name }
end

class Client < CouchRest::Model::Base
  proxied_by :company
  proxy_database_method :id
  proxy_for :invoices
  property :name
  design { view :by_name }
end

class Invoice < CouchRest::Model::Base
  proxied_by :client
  property :date
  design { view :by_date }
end
```

Currently, given the above proxying hierarchy, the migration utility functions (and subsequently the rake tasks) would fail because they only traversed one level of proxying. The changes I've made allow the migration to iterate through all the companies, and then all the clients within each company and update the invoice design docs (it's recursive so this could be taken to even more ridiculous depths than I'm using it for). And while I was in there I wrote some more tests for the basic functionality.

---

Sorry to be continuously bombarding you with pull requests, I just keep hitting edge-cases 😄 
