### PR TITLE
Fix clear cache for delete db

### DIFF
--- a/lib/couchrest/model/support/couchrest_database.rb
+++ b/lib/couchrest/model/support/couchrest_database.rb
@@ -12,6 +12,11 @@ module CouchRest::Model
         super
       end
 
+      def recreate!
+        Thread.current[:couchrest_design_cache] = { }
+        super
+      end
+
     end
   end
 end

--- a/lib/couchrest/model/support/couchrest_database.rb
+++ b/lib/couchrest/model/support/couchrest_database.rb
@@ -3,24 +3,12 @@
 # also emptied. Given that this is a rare event, and the consequences are not 
 # very severe, we just completely empty the cache.
 #
-module CouchRest::Model
-  module Support
-    module Database
-
-      def delete!
-        Thread.current[:couchrest_design_cache] = { }
-        super
-      end
-
-      def recreate!
-        Thread.current[:couchrest_design_cache] = { }
-        super
-      end
-
-    end
-  end
-end
-
 class CouchRest::Database
-  include(CouchRest::Model::Support::Database)
+
+  alias_method :orig_delete!, :delete!
+  def delete!
+    Thread.current[:couchrest_design_cache] = { }
+    orig_delete!
+  end
+
 end


### PR DESCRIPTION
The current way of clearing cache when deleting db does not work well. 
The reason is include does not override the `delete!` method.

In this way this PR is fixing the problem: reopen the class, `alias_method` `delete!` to another name, clear cache in the redefined method, to achieve the overridden effect.
