### PR TITLE
Make View instance respond to model_name

### DIFF
--- a/lib/couchrest/model/designs/view.rb
+++ b/lib/couchrest/model/designs/view.rb
@@ -400,6 +400,14 @@ module CouchRest
           (offset_value / limit_value) + 1
         end
 
+        # == ActiveRecord compatibility support
+
+        # Return the model name for #model just as User::ActiveRecord_Relation
+        # would for better ActiveRecord interoperability
+        def model_name
+          ActiveModel::Name.new(model)
+        end
+
         protected
 
         def include_docs!

--- a/spec/unit/designs/view_spec.rb
+++ b/spec/unit/designs/view_spec.rb
@@ -859,6 +859,14 @@ describe "Design View" do
           end
         end
       end
+
+      describe "ActiveRecord compatibility methods" do
+        describe "#model_name" do
+          it "should use the #model class" do
+            expect(@obj.model_name.to_s).to eql DesignViewModel.to_s
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
In order to have duck-typing-like compatibility with `User::ActiveRecord_Relation` this adds a `CouchRest::Model::Designs::View#model_name` method that maps to the parent model in `View#model`.

For my specific use-case I'm adding this for better out-of-the-box compatibility with Pundit, but I'm sure that there are other gems that could benefit from this as well.
