### PR TITLE
Updating Hashdiff Gem

### DIFF
--- a/couchrest_model.gemspec
+++ b/couchrest_model.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency("couchrest",   "2.0.1")
   s.add_dependency("activemodel", ">= 4.0.2")
   s.add_dependency("tzinfo",      ">= 0.3.22")
-  s.add_dependency("hashdiff",    "~> 0.3")
+  s.add_dependency("hashdiff",    '~> 1.0', '>= 1.0.1')
   s.add_development_dependency("rspec", "~> 3.5.0")
   s.add_development_dependency("rack-test", ">= 0.5.7")
   s.add_development_dependency("rake", ">= 0.8.0", "< 11.0")

--- a/history.md
+++ b/history.md
@@ -1,5 +1,8 @@
 # CouchRest Model Change History
 
+## Changed
+  * Updating Hashdiff Gem to remove warning ([PR](https://github.com/couchrest/couchrest_model/pull/229) @jonmchan).
+
 ## 2.2.0.beta3 - 2020-05-05
   * Do not load files inside app/models/concerns on CouchDB Design Document migrations ([PR](https://github.com/couchrest/couchrest_model/pull/) @dpzaba). This helps to support Rails versions from 4.1 to 5.2.3.
 

--- a/lib/couchrest/model/dirty.rb
+++ b/lib/couchrest/model/dirty.rb
@@ -22,7 +22,7 @@ module CouchRest
         if original_change_data.nil?
           nil
         else
-          HashDiff.diff(original_change_data, current_change_data)
+          Hashdiff.diff(original_change_data, current_change_data)
         end
       end
 


### PR DESCRIPTION
I was tired of seeing rspec error:

```
The HashDiff constant used by this gem conflicts with another gem of a similar name.  As of version 1.0 the HashDiff constant will be completely removed and replaced by Hashdiff.  For more information see https://github.com/liufengyun/hashdiff/issues/45.
```



This PR updates the hashdiff library to the 1.x version and changes the reference to the new `Hashdiff` as opposed to the old `HashDiff` constant.

Addresses https://github.com/liufengyun/hashdiff/issues/45.